### PR TITLE
feat: integrate Chainlink Proof of Reserves (Issue #5)

### DIFF
--- a/contracts/ChainlinkPoRAdapter.sol
+++ b/contracts/ChainlinkPoRAdapter.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./interfaces/IAggregatorV3.sol";
+
+/**
+ * @title ChainlinkPoRAdapter
+ * @notice Adapter to pull reserve data from Chainlink Proof of Reserves feeds.
+ * @dev Part of kcolbchain/stablecoin-toolkit
+ */
+contract ChainlinkPoRAdapter {
+    AggregatorV3Interface public immutable porFeed;
+
+    uint8 public constant FEED_DECIMALS = 8; // Chainlink PoR feeds typically use 8 decimals
+
+    event PorFeedSet(address indexed feed);
+    event ReserveDataPulled(uint256 reserveAmount, uint256 timestamp);
+
+    error FeedNotAvailable();
+    error FeedDataStale(uint256 updatedAt);
+    error InvalidFeedAnswer();
+
+    constructor(address _porFeed) {
+        if (_porFeed == address(0)) revert FeedNotAvailable();
+        porFeed = AggregatorV3Interface(_porFeed);
+        emit PorFeedSet(_porFeed);
+    }
+
+    /**
+     * @notice Pulls the latest reserve amount from the Chainlink PoR feed.
+     * @return reserveAmount The current reserve amount (already scaled to feed decimals)
+     * @return updatedAt The timestamp of the last update
+     */
+    function getLatestReserveAmount() public view returns (uint256 reserveAmount, uint256 updatedAt) {
+        try porFeed.latestRoundData() returns (
+            uint80,
+            int256 answer,
+            uint256,
+            uint256 updatedAt_,
+            uint80
+        ) {
+            if (answer < 0) revert InvalidFeedAnswer();
+            return (uint256(answer), updatedAt_);
+        } catch {
+            revert FeedNotAvailable();
+        }
+    }
+
+    /**
+     * @notice Converts a raw feed answer to stablecoin-equivalent units (6 decimals).
+     * @dev PoR feeds typically return values with 8 decimals; this converts to 6 decimals
+     *      to match the stablecoin's 6-decimal precision used in ReserveManager.
+     * @param rawAmount The raw amount from the PoR feed
+     * @return converted The amount converted to 6-decimal stablecoin units
+     */
+    function convertToStablecoinUnits(uint256 rawAmount) public pure returns (uint256 converted) {
+        // Convert from 8 decimals (feed) to 6 decimals (stablecoin) = divide by 100
+        return rawAmount / 100;
+    }
+
+    /**
+     * @notice Convenience function that pulls and converts in one call.
+     * @return reserveAmount The reserve amount in stablecoin units (6 decimals)
+     * @return updatedAt The timestamp of the last feed update
+     */
+    function getReserveInStablecoinUnits() external returns (uint256 reserveAmount, uint256 updatedAt) {
+        (uint256 rawAmount, uint256 ts) = getLatestReserveAmount();
+        reserveAmount = convertToStablecoinUnits(rawAmount);
+        updatedAt = ts;
+        emit ReserveDataPulled(reserveAmount, ts);
+    }
+
+    /**
+     * @notice Returns feed metadata (description and decimals) for off-chain verification.
+     */
+    function getFeedInfo() external view returns (string memory description, uint8 decimals) {
+        try porFeed.description() returns (string memory desc) {
+            description = desc;
+        } catch {
+            description = "";
+        }
+        try porFeed.decimals() returns (uint8 d) {
+            decimals = d;
+        } catch {
+            decimals = FEED_DECIMALS;
+        }
+    }
+}

--- a/contracts/ReserveManager.sol
+++ b/contracts/ReserveManager.sol
@@ -2,11 +2,13 @@
 pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "./ChainlinkPoRAdapter.sol";
 
 /**
  * @title ReserveManager
  * @notice Multi-asset reserve tracking with proof of reserves and ratio enforcement.
- * @dev Part of kcolbchain/stablecoin-toolkit
+ * @dev Part of kcolbchain/stablecoin-toolkit. Supports both manual attestation
+ *      and Chainlink Proof of Reserves feeds via ChainlinkPoRAdapter.
  */
 contract ReserveManager is Ownable {
     struct ReserveAsset {
@@ -23,11 +25,20 @@ contract ReserveManager is Ownable {
     uint256 public totalSupplyTracked; // updated by Minter
     uint256 public minimumRatioBps;    // e.g. 10000 = 100%, 10500 = 105%
 
+    /// @dev Chainlink PoR adapter for on-chain reserve verification
+    ChainlinkPoRAdapter public porAdapter;
+    /// @dev Canonical reserve asset ID for the Chainlink-backed reserve
+    bytes32 public constant POR_RESERVE_ID = bytes32(0);
+
     event ReserveUpdated(bytes32 indexed assetId, string name, uint256 amount);
     event SupplyUpdated(uint256 newSupply);
     event MinimumRatioUpdated(uint256 newRatioBps);
+    event PorAdapterSet(address indexed adapter);
+    event PorReservePulled(uint256 amount, uint256 updatedAt);
 
     error ReserveRatioTooLow(uint256 currentRatioBps, uint256 requiredRatioBps);
+    error PorAdapterNotSet();
+    error PorFeedFailed(string reason);
 
     constructor(uint256 _minimumRatioBps) Ownable(msg.sender) {
         minimumRatioBps = _minimumRatioBps;
@@ -65,16 +76,74 @@ contract ReserveManager is Ownable {
         emit MinimumRatioUpdated(ratioBps);
     }
 
+    /**
+     * @notice Sets the Chainlink PoR adapter address.
+     * @param adapter Address of the ChainlinkPoRAdapter contract.
+     */
+    function setPorAdapter(address adapter) external onlyOwner {
+        if (adapter == address(0)) revert PorAdapterNotSet();
+        porAdapter = ChainlinkPoRAdapter(adapter);
+        emit PorAdapterSet(adapter);
+    }
+
+    /**
+     * @notice Pulls reserve data from the configured Chainlink PoR feed and
+     *         updates the canonical PoR reserve asset.
+     * @dev The adapter returns values in feed decimals (8); this contract
+     *      converts to stablecoin units (6) before storing.
+     */
+    function pullPorReserve() public onlyOwner returns (uint256 reserveAmount, uint256 updatedAt) {
+        if (address(porAdapter) == address(0)) revert PorAdapterNotSet();
+
+        (uint256 rawAmount, uint256 timestamp) = porAdapter.getLatestReserveAmount();
+
+        // Convert from feed decimals (8) to stablecoin units (6)
+        reserveAmount = rawAmount / 100;
+
+        // Upsert the PoR reserve asset
+        reserves[POR_RESERVE_ID] = ReserveAsset({
+            name: "Chainlink PoR Reserve",
+            amount: reserveAmount,
+            lastUpdated: timestamp,
+            active: true
+        });
+
+        // Add to reserveIds if new
+        bool found = false;
+        for (uint256 i = 0; i < reserveIds.length; i++) {
+            if (reserveIds[i] == POR_RESERVE_ID) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            reserveIds.push(POR_RESERVE_ID);
+        }
+
+        _recalcTotal();
+        emit PorReservePulled(reserveAmount, timestamp);
+        return (reserveAmount, timestamp);
+    }
+
     function getReserveRatioBps() public view returns (uint256) {
         if (totalSupplyTracked == 0) return type(uint256).max;
         return (totalReserves * 10000) / totalSupplyTracked;
     }
 
-    function checkReserveRatio() external view {
+    function checkReserveRatio() public view {
         uint256 ratio = getReserveRatioBps();
         if (ratio < minimumRatioBps) {
             revert ReserveRatioTooLow(ratio, minimumRatioBps);
         }
+    }
+
+    /**
+     * @notice Convenience: pull from PoR and check reserve ratio in one call.
+     */
+    function pullPorReserveAndCheck() external onlyOwner {
+        if (address(porAdapter) == address(0)) revert PorAdapterNotSet();
+        pullPorReserve();
+        checkReserveRatio();
     }
 
     function getReserveCount() external view returns (uint256) {

--- a/contracts/interfaces/IAggregatorV3.sol
+++ b/contracts/interfaces/IAggregatorV3.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface AggregatorV3Interface {
+  function decimals() external view returns (uint8);
+  function description() external view returns (string memory);
+  function version() external view returns (uint256);
+  function latestRoundData()
+    external
+    view
+    returns (
+      uint80 roundId,
+      int256 answer,
+      uint256 startedAt,
+      uint256 updatedAt,
+      uint80 answeredInRound
+    );
+  function getRoundData(uint80 _roundId)
+    external
+    view
+    returns (
+      uint80 roundId,
+      int256 answer,
+      uint256 startedAt,
+      uint256 updatedAt,
+      uint80 answeredInRound
+    );
+}

--- a/contracts/mocks/ChainlinkPoRMock.sol
+++ b/contracts/mocks/ChainlinkPoRMock.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "../interfaces/IAggregatorV3.sol";
+
+/**
+ * @title ChainlinkPoRMock
+ * @notice Mock aggregator that simulates Chainlink Proof of Reserves feed responses.
+ * @dev For testing purposes only. DO NOT use in production.
+ */
+contract ChainlinkPoRMock is AggregatorV3Interface {
+    string private _description = "Mock PoR Feed";
+    uint8 private _decimals = 8;
+    uint256 private _version = 1;
+
+    struct RoundData {
+        uint80 roundId;
+        int256 answer;
+        uint256 startedAt;
+        uint256 updatedAt;
+        uint80 answeredInRound;
+    }
+
+    RoundData[] private _roundHistory;
+    int256 private _currentAnswer;
+    uint80 private _currentRoundId;
+    uint256 private _currentUpdatedAt;
+
+    event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 updatedAt);
+
+    constructor(int256 initialAnswer) {
+        _currentAnswer = initialAnswer;
+        _currentRoundId = 1;
+        _currentUpdatedAt = block.timestamp;
+        _roundHistory.push(RoundData({
+            roundId: 1,
+            answer: initialAnswer,
+            startedAt: block.timestamp,
+            updatedAt: block.timestamp,
+            answeredInRound: 1
+        }));
+    }
+
+    function setAnswer(int256 newAnswer) external {
+        _currentAnswer = newAnswer;
+        _currentRoundId++;
+        _currentUpdatedAt = block.timestamp;
+        _roundHistory.push(RoundData({
+            roundId: _currentRoundId,
+            answer: newAnswer,
+            startedAt: block.timestamp,
+            updatedAt: block.timestamp,
+            answeredInRound: _currentRoundId
+        }));
+        emit AnswerUpdated(newAnswer, _currentRoundId, block.timestamp);
+    }
+
+    function setAnswerWithTimestamp(int256 newAnswer, uint256 timestamp) external {
+        _currentAnswer = newAnswer;
+        _currentRoundId++;
+        _currentUpdatedAt = timestamp;
+        _roundHistory.push(RoundData({
+            roundId: _currentRoundId,
+            answer: newAnswer,
+            startedAt: timestamp,
+            updatedAt: timestamp,
+            answeredInRound: _currentRoundId
+        }));
+        emit AnswerUpdated(newAnswer, _currentRoundId, timestamp);
+    }
+
+    function description() external view override returns (string memory) {
+        return _description;
+    }
+
+    function decimals() external view override returns (uint8) {
+        return _decimals;
+    }
+
+    function version() external view override returns (uint256) {
+        return _version;
+    }
+
+    function getRoundData(uint80 _roundId) external view override returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        require(_roundId > 0 && _roundId <= _currentRoundId, "Round not found");
+        RoundData storage round = _roundHistory[_roundId - 1];
+        return (
+            round.roundId,
+            round.answer,
+            round.startedAt,
+            round.updatedAt,
+            round.answeredInRound
+        );
+    }
+
+    function latestRoundData() external view override returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        RoundData storage round = _roundHistory[_roundHistory.length - 1];
+        return (
+            round.roundId,
+            round.answer,
+            round.startedAt,
+            round.updatedAt,
+            round.answeredInRound
+        );
+    }
+
+}

--- a/test/ChainlinkPoR.test.js
+++ b/test/ChainlinkPoR.test.js
@@ -1,0 +1,213 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("ChainlinkPoRAdapter", function () {
+  let adapter, mockAggregator, owner;
+
+  beforeEach(async function () {
+    [owner] = await ethers.getSigners();
+
+    // Deploy mock aggregator with initial answer of 50_000_000_000 (500 USD with 8 decimals)
+    const MockAggregator = await ethers.getContractFactory("ChainlinkPoRMock");
+    mockAggregator = await MockAggregator.deploy(50_000_000_000n);
+    await mockAggregator.waitForDeployment();
+
+    // Deploy adapter pointing to mock
+    const Adapter = await ethers.getContractFactory("ChainlinkPoRAdapter");
+    adapter = await Adapter.deploy(mockAggregator.target);
+    await adapter.waitForDeployment();
+  });
+
+  it("should set the PoR feed address on construction", async function () {
+    expect(await adapter.porFeed()).to.equal(mockAggregator.target);
+  });
+
+  it("should return correct feed decimals", async function () {
+    expect(await adapter.FEED_DECIMALS()).to.equal(8);
+  });
+
+  it("should pull the latest reserve amount", async function () {
+    const [amount, updatedAt] = await adapter.getLatestReserveAmount();
+    expect(amount).to.equal(50_000_000_000n);
+    expect(updatedAt).to.be.gt(0);
+  });
+
+  it("should convert to stablecoin units (6 decimals)", async function () {
+    // 50_000_000_000 (8 dec) -> 500_000_000 (6 dec) = 500 USD
+    const converted = await adapter.convertToStablecoinUnits(50_000_000_000n);
+    expect(converted).to.equal(500_000_000n);
+  });
+
+  it("should update reserve amount when mock answer changes", async function () {
+    await mockAggregator.setAnswer(100_000_000_000n); // 1000 USD
+    const [amount] = await adapter.getLatestReserveAmount();
+    expect(amount).to.equal(100_000_000_000n);
+  });
+
+  it("should emit ReserveDataPulled on getReserveInStablecoinUnits", async function () {
+    const tx = await adapter.getReserveInStablecoinUnits();
+    await tx.wait();
+    await expect(tx).to.emit(adapter, "ReserveDataPulled");
+  });
+
+  it("should revert if adapter is constructed with zero address", async function () {
+    const Adapter = await ethers.getContractFactory("ChainlinkPoRAdapter");
+    await expect(Adapter.deploy(ethers.ZeroAddress)).to.be.revertedWithCustomError(
+      adapter,
+      "FeedNotAvailable"
+    );
+  });
+});
+
+describe("ChainlinkPoRMock", function () {
+  let mock, owner;
+
+  beforeEach(async function () {
+    [owner] = await ethers.getSigners();
+    const Mock = await ethers.getContractFactory("ChainlinkPoRMock");
+    mock = await Mock.deploy(25_000_000_000n);
+    await mock.waitForDeployment();
+  });
+
+  it("should return initial answer", async function () {
+    const [, answer] = await mock.latestRoundData();
+    expect(answer).to.equal(25_000_000_000n);
+  });
+
+  it("should return correct decimals", async function () {
+    expect(await mock.decimals()).to.equal(8);
+  });
+
+  it("should return description", async function () {
+    expect(await mock.description()).to.equal("Mock PoR Feed");
+  });
+
+  it("should start at round 1", async function () {
+    const [, , , , answeredInRound] = await mock.latestRoundData();
+    expect(answeredInRound).to.equal(1n);
+  });
+
+  it("should update answer and increment round", async function () {
+    await mock.setAnswer(30_000_000_000n);
+    const [, answer, , , answeredInRound] = await mock.latestRoundData();
+    expect(answer).to.equal(30_000_000_000n);
+    expect(answeredInRound).to.equal(2n);
+  });
+
+  it("should set answer with specific timestamp", async function () {
+    const pastTs = 1700000000;
+    await mock.setAnswerWithTimestamp(40_000_000_000n, pastTs);
+    const [, answer, , updatedAt] = await mock.latestRoundData();
+    expect(answer).to.equal(40_000_000_000n);
+    expect(updatedAt).to.equal(pastTs);
+  });
+
+  it("should retrieve specific round data", async function () {
+    await mock.setAnswer(60_000_000_000n);
+    const [roundId, answer] = await mock.getRoundData(1);
+    expect(roundId).to.equal(1n);
+    expect(answer).to.equal(25_000_000_000n);
+  });
+
+  it("should revert on getRoundData for non-existent round", async function () {
+    await expect(mock.getRoundData(99)).to.be.revertedWith("Round not found");
+  });
+});
+
+describe("ReserveManager + ChainlinkPoRAdapter integration", function () {
+  let reserveManager, adapter, mockAggregator, owner;
+
+  beforeEach(async function () {
+    [owner] = await ethers.getSigners();
+
+    const MockAggregator = await ethers.getContractFactory("ChainlinkPoRMock");
+    mockAggregator = await MockAggregator.deploy(100_000_000_000n); // 1000 USD (8 dec)
+    await mockAggregator.waitForDeployment();
+
+    const Adapter = await ethers.getContractFactory("ChainlinkPoRAdapter");
+    adapter = await Adapter.deploy(mockAggregator.target);
+    await adapter.waitForDeployment();
+
+    const ReserveManager = await ethers.getContractFactory("ReserveManager");
+    reserveManager = await ReserveManager.deploy(10000); // 100% minimum
+    await reserveManager.waitForDeployment();
+  });
+
+  it("should set the PoR adapter", async function () {
+    await reserveManager.setPorAdapter(adapter.target);
+    expect(await reserveManager.porAdapter()).to.equal(adapter.target);
+  });
+
+  it("should pull and store PoR reserve data", async function () {
+    await reserveManager.setPorAdapter(adapter.target);
+    // Pull: 100_000_000_000 (8 dec) -> 1_000_000_000 (6 dec) = 1000 USD
+    await expect(reserveManager.pullPorReserve()).to.emit(reserveManager, "PorReservePulled");
+    // Verify total reserves were updated
+    expect(await reserveManager.totalReserves()).to.equal(1_000_000_000n);
+  });
+
+  it("should recalculate total reserves after pulling PoR data", async function () {
+    await reserveManager.setPorAdapter(adapter.target);
+
+    // Add a manual reserve first
+    const assetId = ethers.id("MANUAL_RESERVE");
+    await reserveManager.addReserveAsset(assetId, "Manual Reserve", 500_000_000n); // 500 USD
+
+    await reserveManager.pullPorReserve();
+
+    // PoR = 1000 USD + manual = 1500 USD
+    expect(await reserveManager.totalReserves()).to.equal(1_500_000_000n);
+  });
+
+  it("should pass reserve ratio check when reserves are sufficient", async function () {
+    await reserveManager.setPorAdapter(adapter.target);
+    await reserveManager.pullPorReserve(); // 1000 USD
+    await reserveManager.updateTrackedSupply(1000_000_000n); // 1000 USD supply
+
+    // Ratio = 100% >= 100% minimum — should not revert
+    await reserveManager.checkReserveRatio();
+  });
+
+  it("should revert reserve ratio check when reserves are insufficient", async function () {
+    await reserveManager.setPorAdapter(adapter.target);
+    await reserveManager.pullPorReserve(); // 1000 USD
+    await reserveManager.updateTrackedSupply(2_000_000_000n); // 2000 USD supply
+
+    // Ratio = 50% < 100% minimum — should revert
+    await expect(reserveManager.checkReserveRatio()).to.be.revertedWithCustomError(
+      reserveManager,
+      "ReserveRatioTooLow"
+    );
+  });
+
+  it("should revert pullPorReserve when adapter is not set", async function () {
+    await expect(reserveManager.pullPorReserve()).to.be.revertedWithCustomError(
+      reserveManager,
+      "PorAdapterNotSet"
+    );
+  });
+
+  it("should revert setPorAdapter with zero address", async function () {
+    await expect(
+      reserveManager.setPorAdapter(ethers.ZeroAddress)
+    ).to.be.revertedWithCustomError(reserveManager, "PorAdapterNotSet");
+  });
+
+  it("should update PoR reserve when feed answer changes", async function () {
+    await reserveManager.setPorAdapter(adapter.target);
+    await reserveManager.pullPorReserve(); // 1000 USD
+
+    // Update mock to 2000 USD
+    await mockAggregator.setAnswer(200_000_000_000n);
+    await reserveManager.pullPorReserve();
+
+    expect(await reserveManager.totalReserves()).to.equal(2_000_000_000n);
+  });
+
+  it("should use pullPorReserveAndCheck for atomic pull + ratio check", async function () {
+    await reserveManager.setPorAdapter(adapter.target);
+    await reserveManager.updateTrackedSupply(500_000_000n); // 500 USD
+    // 1000 USD reserves / 500 USD supply = 200% >= 100% minimum — should pass
+    await reserveManager.pullPorReserveAndCheck();
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Issue #5**: Integrate Chainlink Proof of Reserves.

### What was added

1. **contracts/ChainlinkPoRAdapter.sol** - Chainlink PoR adapter
   - `getLatestReserveAmount()` - Pull latest reserve data from Chainlink PoR feed
   - `convertToStablecoinUnits()` - Convert feed data to stablecoin units
   - `getReserveInStablecoinUnits()` - Convenience function combining both

2. **contracts/mocks/ChainlinkPoRMock.sol** - Mock aggregator for testing
   - Implements `AggregatorV3Interface`
   - Allows test to set arbitrary reserve values

3. **contracts/interfaces/IAggregatorV3.sol** - Local interface copy

4. **contracts/ReserveManager.sol** - Updated with PoR integration
   - `setPorAdapter()` - Set Chainlink PoR feed address
   - `pullPorReserve()` - Pull reserve data from feed
   - `pullPorReserveAndCheck()` - Pull and verify against threshold

5. **test/ChainlinkPoR.test.js** - 24 passing tests

### Test results

```
npx hardhat test test/ChainlinkPoR.test.js
# 24 passing ✅
```

### Spec compliance

| Requirement | Status |
|-------------|--------|
| Chainlink PoR feed integration | Y |
| ReserveManager integration | Y |
| Mock aggregator for testing | Y |
| Hardhat tests | Y |

Closes #5