### PR TITLE
feat: add Foundry test suite with fuzz tests (#1)

### DIFF
--- a/forge-test/ComplianceModule.t.sol
+++ b/forge-test/ComplianceModule.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/ComplianceModule.sol";
+
+contract ComplianceModuleTest is Test {
+    ComplianceModule public cm;
+    address public admin = address(1);
+    address public user1 = address(2);
+
+    bytes2 constant US = bytes2("US");
+    bytes2 constant CN = bytes2("CN");
+
+    function setUp() public {
+        vm.prank(admin);
+        cm = new ComplianceModule();
+
+        // Setup: approve user1 KYC and configure US geography
+        vm.startPrank(admin);
+        cm.setKYC(user1, ComplianceModule.KYCStatus.Approved);
+        cm.setGeography(user1, US);
+        cm.configureGeography(US, true, 1_000_000, 5_000_000);
+        vm.stopPrank();
+    }
+
+    function test_approvedUserPassesCompliance() public view {
+        cm.checkCompliance(user1, 500_000);
+    }
+
+    function test_nonKYCUserFails() public {
+        address noKyc = address(99);
+        vm.expectRevert(
+            abi.encodeWithSelector(ComplianceModule.NotKYCApproved.selector, noKyc)
+        );
+        cm.checkCompliance(noKyc, 100);
+    }
+
+    function test_sanctionedUserFails() public {
+        vm.prank(admin);
+        cm.sanction(user1);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ComplianceModule.AddressSanctioned.selector, user1)
+        );
+        cm.checkCompliance(user1, 100);
+    }
+
+    function test_unsanctionRestores() public {
+        vm.startPrank(admin);
+        cm.sanction(user1);
+        cm.unsanction(user1);
+        vm.stopPrank();
+
+        cm.checkCompliance(user1, 500_000);
+    }
+
+    function test_exceedsTxLimit() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(ComplianceModule.ExceedsTxLimit.selector, 2_000_000, 1_000_000)
+        );
+        cm.checkCompliance(user1, 2_000_000);
+    }
+
+    function test_restrictedGeography() public {
+        address cnUser = address(10);
+        vm.startPrank(admin);
+        cm.setKYC(cnUser, ComplianceModule.KYCStatus.Approved);
+        cm.setGeography(cnUser, CN);
+        // CN not configured → not allowed
+        cm.configureGeography(CN, false, 0, 0);
+        vm.stopPrank();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ComplianceModule.GeographyRestricted.selector, CN)
+        );
+        cm.checkCompliance(cnUser, 100);
+    }
+
+    function test_dailyLimitEnforced() public {
+        // Record spending up to limit
+        vm.startPrank(admin);
+        cm.recordSpend(user1, 4_500_000);
+        vm.stopPrank();
+
+        // Next tx should push over daily limit
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ComplianceModule.ExceedsDailyLimit.selector,
+                4_500_000 + 600_000,
+                5_000_000
+            )
+        );
+        cm.checkCompliance(user1, 600_000);
+    }
+
+    // ==================== Fuzz Tests ====================
+
+    function testFuzz_withinTxLimitPasses(uint256 amount) public view {
+        amount = bound(amount, 0, 1_000_000);
+        cm.checkCompliance(user1, amount);
+    }
+
+    function testFuzz_overTxLimitReverts(uint256 amount) public {
+        amount = bound(amount, 1_000_001, type(uint128).max);
+        vm.expectRevert();
+        cm.checkCompliance(user1, amount);
+    }
+}

--- a/forge-test/Minter.t.sol
+++ b/forge-test/Minter.t.sol
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/Stablecoin.sol";
+import "../contracts/Minter.sol";
+import "../contracts/ReserveManager.sol";
+import "../contracts/ComplianceModule.sol";
+
+contract MinterTest is Test {
+    Stablecoin public coin;
+    Minter public minter;
+    ReserveManager public rm;
+    ComplianceModule public cm;
+
+    address public admin = address(1);
+    address public user1 = address(2);
+    address public feeCollector = address(3);
+
+    bytes2 constant US = bytes2("US");
+
+    function setUp() public {
+        vm.startPrank(admin);
+
+        coin = new Stablecoin("Test Stablecoin", "TSTBL", admin);
+        rm = new ReserveManager(10_000); // 100% minimum
+        cm = new ComplianceModule();
+
+        minter = new Minter(
+            address(coin),
+            address(rm),
+            address(cm),
+            10, // 0.1% mint fee
+            10, // 0.1% redeem fee
+            feeCollector
+        );
+
+        // Grant MINTER_ROLE to minter contract
+        coin.grantRole(coin.MINTER_ROLE(), address(minter));
+
+        // Transfer ReserveManager ownership to minter
+        rm.transferOwnership(address(minter));
+
+        // Transfer ComplianceModule ownership to minter
+        cm.transferOwnership(address(minter));
+
+        // Setup reserves
+        // Need to do this before ownership transfer
+        vm.stopPrank();
+
+        // Re-setup reserves via minter's owner (admin)
+        // Actually ReserveManager is now owned by minter, so admin can't call it directly
+        // The Minter contract calls rm.updateTrackedSupply and rm.checkReserveRatio
+        // But addReserveAsset must be called by owner (minter contract) 
+        // This is a design limitation - let's set reserves before transfer
+
+        // Reset: redeploy with proper setup order
+        vm.startPrank(admin);
+        coin = new Stablecoin("Test Stablecoin", "TSTBL", admin);
+        rm = new ReserveManager(10_000);
+        cm = new ComplianceModule();
+
+        // Setup reserves BEFORE transferring ownership
+        rm.addReserveAsset(keccak256("USD_BANK"), "USD Bank", 100_000_000_000);
+
+        // Setup compliance
+        cm.setKYC(user1, ComplianceModule.KYCStatus.Approved);
+        cm.setGeography(user1, US);
+        cm.configureGeography(US, true, 100_000_000_000, 100_000_000_000);
+
+        minter = new Minter(
+            address(coin),
+            address(rm),
+            address(cm),
+            10, // 0.1% mint fee
+            10, // 0.1% redeem fee
+            feeCollector
+        );
+
+        coin.grantRole(coin.MINTER_ROLE(), address(minter));
+        rm.transferOwnership(address(minter));
+        cm.transferOwnership(address(minter));
+
+        // Authorize admin as minter
+        minter.authorizeMinter(admin);
+
+        vm.stopPrank();
+    }
+
+    function test_mintWithFee() public {
+        vm.prank(admin);
+        minter.mint(user1, 1_000_000);
+
+        // 0.1% fee on 1_000_000 = 1_000
+        assertEq(coin.balanceOf(user1), 999_000);
+        assertEq(coin.balanceOf(feeCollector), 1_000);
+    }
+
+    function test_unauthorizedMinterReverts() public {
+        vm.prank(address(99));
+        vm.expectRevert(abi.encodeWithSelector(Minter.NotAuthorizedMinter.selector));
+        minter.mint(user1, 1_000_000);
+    }
+
+    function test_redeem() public {
+        vm.prank(admin);
+        minter.mint(user1, 1_000_000);
+
+        // Approve minter to burn
+        vm.prank(user1);
+        coin.approve(address(minter), type(uint256).max);
+
+        vm.prank(user1);
+        minter.redeem(500_000);
+
+        assertEq(minter.getRedemptionCount(), 1);
+    }
+
+    function test_settleRedemption() public {
+        vm.prank(admin);
+        minter.mint(user1, 1_000_000);
+
+        vm.prank(user1);
+        coin.approve(address(minter), type(uint256).max);
+
+        vm.prank(user1);
+        minter.redeem(500_000);
+
+        vm.prank(admin);
+        minter.settleRedemption(0);
+
+        (, , , , bool settled) = minter.redemptions(0);
+        assertTrue(settled);
+    }
+
+    function test_doubleSettleReverts() public {
+        vm.prank(admin);
+        minter.mint(user1, 1_000_000);
+
+        vm.prank(user1);
+        coin.approve(address(minter), type(uint256).max);
+
+        vm.prank(user1);
+        minter.redeem(500_000);
+
+        vm.startPrank(admin);
+        minter.settleRedemption(0);
+        vm.expectRevert(abi.encodeWithSelector(Minter.AlreadySettled.selector));
+        minter.settleRedemption(0);
+        vm.stopPrank();
+    }
+
+    function test_setFees() public {
+        vm.prank(admin);
+        minter.setFees(50, 50); // 0.5%
+        assertEq(minter.mintFeeBps(), 50);
+        assertEq(minter.redeemFeeBps(), 50);
+    }
+
+    // ==================== Fuzz Tests ====================
+
+    function testFuzz_mintFeeCalculation(uint256 amount) public {
+        amount = bound(amount, 10_000, 1_000_000_000); // min 0.01 token
+
+        vm.prank(admin);
+        minter.mint(user1, amount);
+
+        uint256 expectedFee = (amount * 10) / 10_000;
+        uint256 expectedNet = amount - expectedFee;
+
+        assertEq(coin.balanceOf(user1), expectedNet);
+        assertEq(coin.balanceOf(feeCollector), expectedFee);
+    }
+}

--- a/forge-test/ReserveManager.t.sol
+++ b/forge-test/ReserveManager.t.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/ReserveManager.sol";
+
+contract ReserveManagerTest is Test {
+    ReserveManager public rm;
+    address public admin = address(1);
+    bytes32 public usdBank = keccak256("USD_BANK");
+    bytes32 public tbills = keccak256("T_BILLS");
+
+    function setUp() public {
+        vm.prank(admin);
+        rm = new ReserveManager(10_000); // 100% minimum ratio
+    }
+
+    function test_addReserveAsset() public {
+        vm.prank(admin);
+        rm.addReserveAsset(usdBank, "USD Bank Deposit", 10_000_000);
+        assertEq(rm.totalReserves(), 10_000_000);
+        assertEq(rm.getReserveCount(), 1);
+    }
+
+    function test_multipleReserves() public {
+        vm.startPrank(admin);
+        rm.addReserveAsset(usdBank, "USD Bank", 5_000_000);
+        rm.addReserveAsset(tbills, "T-Bills", 5_000_000);
+        vm.stopPrank();
+
+        assertEq(rm.totalReserves(), 10_000_000);
+        assertEq(rm.getReserveCount(), 2);
+    }
+
+    function test_updateReserve() public {
+        vm.startPrank(admin);
+        rm.addReserveAsset(usdBank, "USD Bank", 5_000_000);
+        rm.updateReserve(usdBank, 8_000_000);
+        vm.stopPrank();
+
+        assertEq(rm.totalReserves(), 8_000_000);
+    }
+
+    function test_reserveRatioSufficient() public {
+        vm.startPrank(admin);
+        rm.addReserveAsset(usdBank, "USD Bank", 10_000_000);
+        rm.updateTrackedSupply(10_000_000);
+        rm.checkReserveRatio(); // should not revert
+        vm.stopPrank();
+    }
+
+    function test_reserveRatioInsufficient() public {
+        vm.startPrank(admin);
+        rm.addReserveAsset(usdBank, "USD Bank", 5_000_000);
+        rm.updateTrackedSupply(10_000_000);
+        vm.expectRevert(
+            abi.encodeWithSelector(ReserveManager.ReserveRatioTooLow.selector, 5_000, 10_000)
+        );
+        rm.checkReserveRatio();
+        vm.stopPrank();
+    }
+
+    function test_reserveRatioWithZeroSupply() public view {
+        // Should return max uint when supply is zero
+        assertEq(rm.getReserveRatioBps(), type(uint256).max);
+    }
+
+    function test_setMinimumRatio() public {
+        vm.prank(admin);
+        rm.setMinimumRatio(10_500); // 105%
+        assertEq(rm.minimumRatioBps(), 10_500);
+    }
+
+    // ==================== Fuzz Tests ====================
+
+    function testFuzz_reserveRatioCalculation(uint256 reserves, uint256 supply) public {
+        reserves = bound(reserves, 0, type(uint128).max);
+        supply = bound(supply, 1, type(uint128).max);
+
+        vm.startPrank(admin);
+        rm.addReserveAsset(usdBank, "USD Bank", reserves);
+        rm.updateTrackedSupply(supply);
+        vm.stopPrank();
+
+        uint256 ratio = rm.getReserveRatioBps();
+        assertEq(ratio, (reserves * 10_000) / supply);
+    }
+}

--- a/forge-test/Stablecoin.t.sol
+++ b/forge-test/Stablecoin.t.sol
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/Stablecoin.sol";
+
+contract StablecoinTest is Test {
+    Stablecoin public coin;
+    address public admin = address(1);
+    address public user1 = address(2);
+    address public user2 = address(3);
+    address public nobody = address(4);
+
+    function setUp() public {
+        vm.prank(admin);
+        coin = new Stablecoin("Test Stablecoin", "TSTBL", admin);
+    }
+
+    // ==================== Basic Properties ====================
+
+    function test_nameAndSymbol() public view {
+        assertEq(coin.name(), "Test Stablecoin");
+        assertEq(coin.symbol(), "TSTBL");
+    }
+
+    function test_decimalsIs6() public view {
+        assertEq(coin.decimals(), 6);
+    }
+
+    function test_adminHasAllRoles() public view {
+        assertTrue(coin.hasRole(coin.DEFAULT_ADMIN_ROLE(), admin));
+        assertTrue(coin.hasRole(coin.MINTER_ROLE(), admin));
+        assertTrue(coin.hasRole(coin.PAUSER_ROLE(), admin));
+        assertTrue(coin.hasRole(coin.BLACKLISTER_ROLE(), admin));
+    }
+
+    // ==================== Minting ====================
+
+    function test_minterCanMint() public {
+        vm.prank(admin);
+        coin.mint(user1, 1_000_000);
+        assertEq(coin.balanceOf(user1), 1_000_000);
+    }
+
+    function test_nonMinterCannotMint() public {
+        vm.prank(nobody);
+        vm.expectRevert();
+        coin.mint(user1, 1_000_000);
+    }
+
+    function test_cannotMintToBlacklistedAddress() public {
+        vm.startPrank(admin);
+        coin.blacklist(user1);
+        vm.expectRevert(abi.encodeWithSelector(Stablecoin.AccountBlacklisted.selector, user1));
+        coin.mint(user1, 1_000_000);
+        vm.stopPrank();
+    }
+
+    // ==================== Burn ====================
+
+    function test_holderCanBurn() public {
+        vm.prank(admin);
+        coin.mint(user1, 1_000_000);
+
+        vm.prank(user1);
+        coin.burn(500_000);
+        assertEq(coin.balanceOf(user1), 500_000);
+    }
+
+    // ==================== Pause ====================
+
+    function test_pauseBlocksTransfers() public {
+        vm.prank(admin);
+        coin.mint(user1, 1_000_000);
+
+        vm.prank(admin);
+        coin.pause();
+
+        vm.prank(user1);
+        vm.expectRevert();
+        coin.transfer(user2, 500_000);
+    }
+
+    function test_unpauseRestoresTransfers() public {
+        vm.prank(admin);
+        coin.mint(user1, 1_000_000);
+
+        vm.prank(admin);
+        coin.pause();
+
+        vm.prank(admin);
+        coin.unpause();
+
+        vm.prank(user1);
+        coin.transfer(user2, 500_000);
+        assertEq(coin.balanceOf(user2), 500_000);
+    }
+
+    function test_nonPauserCannotPause() public {
+        vm.prank(nobody);
+        vm.expectRevert();
+        coin.pause();
+    }
+
+    // ==================== Blacklist ====================
+
+    function test_blacklistBlocksTransferFrom() public {
+        vm.prank(admin);
+        coin.mint(user1, 1_000_000);
+
+        vm.prank(admin);
+        coin.blacklist(user1);
+
+        assertTrue(coin.isBlacklisted(user1));
+
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Stablecoin.AccountBlacklisted.selector, user1));
+        coin.transfer(user2, 500_000);
+    }
+
+    function test_blacklistBlocksReceiving() public {
+        vm.prank(admin);
+        coin.mint(user1, 1_000_000);
+
+        vm.prank(admin);
+        coin.blacklist(user2);
+
+        vm.prank(user1);
+        vm.expectRevert(abi.encodeWithSelector(Stablecoin.AccountBlacklisted.selector, user2));
+        coin.transfer(user2, 500_000);
+    }
+
+    function test_unblacklistRestoresTransfer() public {
+        vm.prank(admin);
+        coin.mint(user1, 1_000_000);
+
+        vm.startPrank(admin);
+        coin.blacklist(user1);
+        coin.unblacklist(user1);
+        vm.stopPrank();
+
+        assertFalse(coin.isBlacklisted(user1));
+
+        vm.prank(user1);
+        coin.transfer(user2, 500_000);
+        assertEq(coin.balanceOf(user2), 500_000);
+    }
+
+    // ==================== Fuzz Tests ====================
+
+    function testFuzz_mintAnyAmount(uint256 amount) public {
+        amount = bound(amount, 0, type(uint128).max);
+        vm.prank(admin);
+        coin.mint(user1, amount);
+        assertEq(coin.balanceOf(user1), amount);
+        assertEq(coin.totalSupply(), amount);
+    }
+
+    function testFuzz_burnNeverExceedsBalance(uint256 mintAmt, uint256 burnAmt) public {
+        mintAmt = bound(mintAmt, 1, type(uint128).max);
+        burnAmt = bound(burnAmt, 0, mintAmt);
+
+        vm.prank(admin);
+        coin.mint(user1, mintAmt);
+
+        vm.prank(user1);
+        coin.burn(burnAmt);
+
+        assertEq(coin.balanceOf(user1), mintAmt - burnAmt);
+    }
+
+    function testFuzz_burnOverBalanceReverts(uint256 mintAmt, uint256 extra) public {
+        mintAmt = bound(mintAmt, 0, type(uint128).max - 1);
+        extra = bound(extra, 1, type(uint64).max);
+
+        vm.prank(admin);
+        coin.mint(user1, mintAmt);
+
+        vm.prank(user1);
+        vm.expectRevert();
+        coin.burn(mintAmt + extra);
+    }
+
+    function testFuzz_transferPreservesTotalSupply(uint256 amount, uint256 xfer) public {
+        amount = bound(amount, 1, type(uint128).max);
+        xfer = bound(xfer, 0, amount);
+
+        vm.prank(admin);
+        coin.mint(user1, amount);
+
+        uint256 supplyBefore = coin.totalSupply();
+
+        vm.prank(user1);
+        coin.transfer(user2, xfer);
+
+        assertEq(coin.totalSupply(), supplyBefore);
+        assertEq(coin.balanceOf(user1) + coin.balanceOf(user2), amount);
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,15 @@
+[profile.default]
+src = "contracts"
+out = "forge-out"
+libs = ["node_modules"]
+solc = "0.8.24"
+optimizer = true
+optimizer-runs = 200
+
+[profile.default.fuzz]
+runs = 256
+max_test_rejects = 65536
+
+[fmt]
+line_length = 100
+tab_width = 4

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,1 @@
+@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/


### PR DESCRIPTION
Closes #1.

## What
Comprehensive Foundry/Forge test suite mirroring the existing Hardhat tests, with added fuzz tests for edge cases.

## Files Added
- `foundry.toml` — Foundry config (optimizer, 256 fuzz runs)
- `remappings.txt` — OpenZeppelin remappings
- `forge-test/Stablecoin.t.sol` — 12 tests (mint, burn, pause, blacklist + 4 fuzz)
- `forge-test/ReserveManager.t.sol` — 7 tests (reserves, ratio + 1 fuzz)
- `forge-test/ComplianceModule.t.sol` — 8 tests (KYC, sanctions, geo, limits + 2 fuzz)
- `forge-test/Minter.t.sol` — 7 tests (fees, auth, redeem, settle + 1 fuzz)

## Fuzz Tests
- `testFuzz_mintAnyAmount` — arbitrary mint amounts stay consistent
- `testFuzz_burnNeverExceedsBalance` — burn ≤ balance always succeeds
- `testFuzz_burnOverBalanceReverts` — burn > balance always reverts
- `testFuzz_transferPreservesTotalSupply` — transfers preserve total supply
- `testFuzz_reserveRatioCalculation` — ratio math is correct for any reserves/supply
- `testFuzz_mintFeeCalculation` — fees computed correctly for any amount
- `testFuzz_withinTxLimitPasses` / `testFuzz_overTxLimitReverts` — compliance boundaries

## Run
```bash
forge install
forge test -vv
forge snapshot  # gas snapshots
```