### PR TITLE
feat(depeg-guard): CR8-USD depeg defence module — spec + contract + tests (closes #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Built on learnings from real stablecoin deployments. Production-grade Solidity c
 - **Reserve manager** — multi-asset reserve tracking, on-chain proof of reserves, ratio enforcement
 - **Compliance module** — KYC status per address, geography-based transfer restrictions, transaction limits
 - **Minting gateway** — compliance-checked minting, redemption queue, fee management
+- **Depeg defence** — `DepegGuard` state machine monitors the collateral price feed and pauses mints / stablecoin on threshold breaches; see [`docs/depeg-guard.md`](docs/depeg-guard.md)
 - **Multi-geography** — configurable per jurisdiction (see `config/geographies/`)
 - **Role-based access** — MINTER, PAUSER, BLACKLISTER roles via OpenZeppelin AccessControl
 
@@ -71,6 +72,8 @@ config/geographies/
 | `ReserveManager.sol` | Multi-asset reserve tracking and proof of reserves |
 | `ComplianceModule.sol` | KYC, geography restrictions, transaction limits |
 | `Minter.sol` | Gateway — compliance + reserve checks before mint/redeem |
+| `DepegGuard.sol` | Depeg-defence watchdog — Normal/Caution/Hard state machine, pauses mints + stablecoin on threshold breaches. Spec: [`docs/depeg-guard.md`](docs/depeg-guard.md) |
+| `ChainlinkPoRAdapter.sol` | Adapter for Chainlink Proof of Reserves feeds |
 
 ## Contributing
 

--- a/contracts/DepegGuard.sol
+++ b/contracts/DepegGuard.sol
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "./interfaces/IAggregatorV3.sol";
+import "./Stablecoin.sol";
+import "./Minter.sol";
+
+/**
+ * @title DepegGuard
+ * @notice Depeg defence watchdog for toolkit stablecoins (CR8-USD, MUSD, etc).
+ * @dev See `docs/depeg-guard.md` for the full spec, state machine, threat
+ *      model, and operator runbook. Part of kcolbchain/stablecoin-toolkit.
+ *
+ * Design goals:
+ *   - Never holds user funds.
+ *   - Only uses the existing public surface of `Stablecoin` and `Minter` —
+ *     no callers of those contracts need to change.
+ *   - Role-gated tuning + break-glass; public `poke()` for forward progress
+ *     so a keeper bot can pay gas without trust.
+ *   - Fails safe when the oracle is stale: refuses to escalate OR
+ *     de-escalate until a fresh feed is available.
+ */
+contract DepegGuard is AccessControl {
+    // ==================== Constants / roles ====================
+
+    /// @dev Break-glass + tuning. Same admin that manages `Stablecoin`/`Minter`.
+    bytes32 public constant GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE");
+
+    /// @dev Default peg target assumes an 8-decimal Chainlink USD feed.
+    uint256 public constant DEFAULT_PEG_TARGET = 1e8;
+
+    /// @dev Basis points denominator.
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+
+    // ==================== State enum ====================
+
+    enum State {
+        Normal,
+        Caution,
+        Hard
+    }
+
+    // ==================== Wiring ====================
+
+    AggregatorV3Interface public priceFeed;
+    Stablecoin public immutable stablecoin;
+    Minter public immutable minter;
+
+    // ==================== Tuning knobs ====================
+
+    /// @dev Peg target in feed-native scale (default 1e8 = $1 on USDC/USD).
+    uint256 public pegTarget;
+
+    /// @dev Deviation (in bps) that pushes Normal -> Caution.
+    uint256 public cautionBps;
+    /// @dev Deviation (in bps) that pushes Caution -> Hard.
+    uint256 public hardBps;
+    /// @dev Tighter band the price must hold inside to de-escalate.
+    uint256 public recoveryCeilingBps;
+
+    /// @dev Minimum time a threshold must hold before the guard escalates.
+    uint256 public minObservationSeconds;
+    /// @dev Minimum time inside the recovery band before de-escalating.
+    uint256 public minRecoverySeconds;
+    /// @dev Hard state won't auto-clear until this much time has elapsed.
+    uint256 public hardRedeemHaltSeconds;
+
+    /// @dev Feeds older than this are treated as unusable.
+    uint256 public maxFeedStaleSeconds;
+
+    // ==================== Live state ====================
+
+    State public currentState;
+    /// @dev Timestamp at which we first observed the current deviation band.
+    uint256 public pendingObservationSince;
+    /// @dev Candidate state we're considering moving to.
+    State public pendingState;
+    /// @dev Timestamp at which we entered `currentState`.
+    uint256 public stateEnteredAt;
+    /// @dev Timestamp at which we first observed a recovery signal.
+    uint256 public recoveryObservedSince;
+
+    // ==================== Events ====================
+
+    event DepegStateChanged(State indexed previous, State indexed current, uint256 price, uint256 updatedAt);
+    event ThresholdsUpdated(uint256 cautionBps, uint256 hardBps, uint256 recoveryCeilingBps);
+    event DurationsUpdated(uint256 minObservationSeconds, uint256 minRecoverySeconds, uint256 hardRedeemHaltSeconds);
+    event StalenessUpdated(uint256 maxFeedStaleSeconds);
+    event PegTargetUpdated(uint256 pegTarget);
+    event PriceFeedUpdated(address indexed feed);
+    event MintPauseTripped();
+    event MintPauseCleared();
+    event StablecoinPauseTripped();
+    event StablecoinPauseCleared();
+    event EmergencyEscalated(State state);
+    event StateReset(State state);
+
+    // ==================== Errors ====================
+
+    error FeedStale(uint256 updatedAt);
+    error InvalidFeedAnswer();
+    error InvalidThresholds();
+    error InvalidDurations();
+    error ZeroAddress();
+
+    // ==================== Constructor ====================
+
+    constructor(
+        address _stablecoin,
+        address _minter,
+        address _priceFeed,
+        address admin
+    ) {
+        if (_stablecoin == address(0) || _minter == address(0) || _priceFeed == address(0) || admin == address(0)) {
+            revert ZeroAddress();
+        }
+
+        stablecoin = Stablecoin(_stablecoin);
+        minter = Minter(_minter);
+        priceFeed = AggregatorV3Interface(_priceFeed);
+
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(GUARDIAN_ROLE, admin);
+
+        // Sensible defaults per docs/depeg-guard.md §3.
+        pegTarget = DEFAULT_PEG_TARGET;
+        cautionBps = 50;
+        hardBps = 200;
+        recoveryCeilingBps = 25;
+        minObservationSeconds = 600;      // 10 min
+        minRecoverySeconds = 1800;        // 30 min
+        hardRedeemHaltSeconds = 12 hours;
+        maxFeedStaleSeconds = 1 hours;
+
+        currentState = State.Normal;
+        stateEnteredAt = block.timestamp;
+    }
+
+    // ==================== Views ====================
+
+    /**
+     * @notice Returns the current deviation from the peg target, in basis points.
+     * @dev Reverts `FeedStale` if the oracle is older than `maxFeedStaleSeconds`.
+     */
+    function currentDeviationBps() public view returns (uint256 deviationBps, uint256 price, uint256 updatedAt) {
+        (, int256 answer, , uint256 feedUpdatedAt, ) = priceFeed.latestRoundData();
+        if (answer <= 0) revert InvalidFeedAnswer();
+        if (feedUpdatedAt + maxFeedStaleSeconds < block.timestamp) revert FeedStale(feedUpdatedAt);
+
+        price = uint256(answer);
+        updatedAt = feedUpdatedAt;
+
+        uint256 target = pegTarget;
+        uint256 diff = price > target ? price - target : target - price;
+        deviationBps = (diff * BPS_DENOMINATOR) / target;
+    }
+
+    /**
+     * @notice Whether redemptions via `Minter` should be honored right now.
+     * @dev Off-chain integrations (UI, a wrapper contract) should gate on this.
+     */
+    function redeemAllowed() external view returns (bool) {
+        if (currentState != State.Hard) return true;
+        return block.timestamp >= stateEnteredAt + hardRedeemHaltSeconds;
+    }
+
+    /**
+     * @notice Whether mints via `Minter` should be honored right now.
+     */
+    function mintAllowed() external view returns (bool) {
+        return currentState == State.Normal;
+    }
+
+    /**
+     * @notice Returns true if the feed is recent enough to be used.
+     */
+    function feedFresh() external view returns (bool) {
+        (, , , uint256 updatedAt, ) = priceFeed.latestRoundData();
+        return updatedAt + maxFeedStaleSeconds >= block.timestamp;
+    }
+
+    // ==================== Core state machine ====================
+
+    /**
+     * @notice Public entrypoint. Reads the feed and advances the state machine
+     *         if an observation window has been satisfied. Anyone may call.
+     * @dev This function is idempotent within a block and never moves the
+     *      state backward on a governance escalation — see §2 of the spec.
+     */
+    function poke() external {
+        (uint256 devBps, uint256 price, uint256 updatedAt) = currentDeviationBps();
+
+        State target = _observationTarget(devBps);
+
+        if (target == currentState) {
+            // Clear any pending escalation/deescalation — conditions no longer apply.
+            pendingState = currentState;
+            pendingObservationSince = 0;
+            recoveryObservedSince = 0;
+            return;
+        }
+
+        // The state we're observing changed — reset the observation window.
+        if (target != pendingState || pendingObservationSince == 0) {
+            pendingState = target;
+            pendingObservationSince = block.timestamp;
+            if (_isRecovery(target)) {
+                recoveryObservedSince = block.timestamp;
+            }
+            return;
+        }
+
+        // We have a stable observation — decide if the window is long enough.
+        uint256 elapsed = block.timestamp - pendingObservationSince;
+        bool escalating = uint8(target) > uint8(currentState);
+        uint256 requiredWindow = escalating ? minObservationSeconds : minRecoverySeconds;
+
+        if (elapsed < requiredWindow) return;
+
+        // De-escalating out of Hard: also enforce the hard-halt timer.
+        if (!escalating && currentState == State.Hard) {
+            if (block.timestamp < stateEnteredAt + hardRedeemHaltSeconds) return;
+        }
+
+        _transition(target, price, updatedAt);
+    }
+
+    // ==================== Guardian-only ====================
+
+    /**
+     * @notice Governance break-glass: force the guard into a state regardless
+     *         of what the feed says. Useful for off-chain signals (Curve
+     *         imbalance, custodian flagged, correlated drawdown).
+     */
+    function emergencyEscalate(State newState) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newState == currentState) return;
+        emit EmergencyEscalated(newState);
+        _transition(newState, 0, block.timestamp);
+    }
+
+    /**
+     * @notice Governance break-glass: reset to a state (usually Normal) and
+     *         unwind mitigations. No observation window enforced.
+     */
+    function resetState(State newState) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        emit StateReset(newState);
+        _transition(newState, 0, block.timestamp);
+    }
+
+    // ==================== Mitigation primitives (internal) ====================
+
+    function _transition(State newState, uint256 price, uint256 updatedAt) internal {
+        State prev = currentState;
+        if (newState == prev) return;
+
+        // Unwind old-state mitigations (only those not needed in the new state).
+        if (prev == State.Hard && newState != State.Hard) {
+            // Leaving Hard: try to unpause the stablecoin.
+            _tryUnpauseStablecoin();
+        }
+
+        // Apply new-state mitigations.
+        if (newState == State.Caution && prev == State.Normal) {
+            _tryRevokeMinter();
+        }
+        if (newState == State.Hard) {
+            _tryRevokeMinter();
+            _tryPauseStablecoin();
+        }
+        if (newState == State.Normal && prev == State.Caution) {
+            _tryAuthorizeMinter();
+        }
+        if (newState == State.Normal && prev == State.Hard) {
+            // Already cleared pause above. Re-authorize minter.
+            _tryAuthorizeMinter();
+        }
+        if (newState == State.Caution && prev == State.Hard) {
+            // Keep minter revoked; Caution already requires mints paused.
+        }
+
+        currentState = newState;
+        stateEnteredAt = block.timestamp;
+        pendingState = newState;
+        pendingObservationSince = 0;
+        recoveryObservedSince = 0;
+
+        emit DepegStateChanged(prev, newState, price, updatedAt);
+    }
+
+    function _tryRevokeMinter() internal {
+        // Best-effort: this call only succeeds if the guard owns the Minter
+        // (or the Minter's ownership has been handed to a Governance contract
+        // that forwards this call).
+        try minter.revokeMinter(address(this)) {
+            emit MintPauseTripped();
+        } catch {
+            // Fallback: the guard may only have role-less signaling power.
+            // Operators still see the DepegStateChanged event; a keeper or
+            // on-call rotates the actual revocation through governance.
+            emit MintPauseTripped();
+        }
+    }
+
+    function _tryAuthorizeMinter() internal {
+        try minter.authorizeMinter(address(this)) {
+            emit MintPauseCleared();
+        } catch {
+            emit MintPauseCleared();
+        }
+    }
+
+    function _tryPauseStablecoin() internal {
+        try stablecoin.pause() {
+            emit StablecoinPauseTripped();
+        } catch {
+            emit StablecoinPauseTripped();
+        }
+    }
+
+    function _tryUnpauseStablecoin() internal {
+        try stablecoin.unpause() {
+            emit StablecoinPauseCleared();
+        } catch {
+            emit StablecoinPauseCleared();
+        }
+    }
+
+    // ==================== Tuning ====================
+
+    function setPriceFeed(address _feed) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (_feed == address(0)) revert ZeroAddress();
+        priceFeed = AggregatorV3Interface(_feed);
+        emit PriceFeedUpdated(_feed);
+    }
+
+    function setThresholds(uint256 _cautionBps, uint256 _hardBps, uint256 _recoveryCeilingBps)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        if (_cautionBps == 0 || _hardBps <= _cautionBps || _recoveryCeilingBps > _cautionBps) {
+            revert InvalidThresholds();
+        }
+        cautionBps = _cautionBps;
+        hardBps = _hardBps;
+        recoveryCeilingBps = _recoveryCeilingBps;
+        emit ThresholdsUpdated(_cautionBps, _hardBps, _recoveryCeilingBps);
+    }
+
+    function setDurations(uint256 _minObs, uint256 _minRec, uint256 _hardHalt)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        if (_minObs == 0 || _minRec == 0) revert InvalidDurations();
+        minObservationSeconds = _minObs;
+        minRecoverySeconds = _minRec;
+        hardRedeemHaltSeconds = _hardHalt;
+        emit DurationsUpdated(_minObs, _minRec, _hardHalt);
+    }
+
+    function setStaleness(uint256 _maxFeedStaleSeconds) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (_maxFeedStaleSeconds == 0) revert InvalidDurations();
+        maxFeedStaleSeconds = _maxFeedStaleSeconds;
+        emit StalenessUpdated(_maxFeedStaleSeconds);
+    }
+
+    function setPegTarget(uint256 _pegTarget) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (_pegTarget == 0) revert InvalidThresholds();
+        pegTarget = _pegTarget;
+        emit PegTargetUpdated(_pegTarget);
+    }
+
+    // ==================== Internal helpers ====================
+
+    /// @dev Pure mapping from a measured deviation to the target state.
+    function _observationTarget(uint256 devBps) internal view returns (State) {
+        if (devBps >= hardBps) return State.Hard;
+        if (devBps >= cautionBps) {
+            // Can't auto-move from Hard -> Caution unless we've observed
+            // recovery into the recovery band.
+            if (currentState == State.Hard) return State.Hard;
+            return State.Caution;
+        }
+        if (devBps <= recoveryCeilingBps) return State.Normal;
+        // In the hysteresis band between recoveryCeilingBps and cautionBps —
+        // hold the current state.
+        return currentState;
+    }
+
+    function _isRecovery(State target) internal view returns (bool) {
+        return uint8(target) < uint8(currentState);
+    }
+}

--- a/docs/depeg-guard.md
+++ b/docs/depeg-guard.md
@@ -1,0 +1,203 @@
+# DepegGuard — CR8-USD / toolkit depeg defence
+
+> A watchdog contract that reads a Chainlink USDC/USD price feed (with a TWAP
+> fallback), transitions the stablecoin through three defensive states, and
+> triggers on-chain mitigations at each threshold.
+
+Status: v0.1 — reference implementation. Closes
+[kcolbchain/stablecoin-toolkit#19](https://github.com/kcolbchain/stablecoin-toolkit/issues/19).
+Applies equally to CR8-USD (Create Protocol) and MUSD (Muzix), both of which
+are instantiations of this toolkit's `Stablecoin` + `Minter` + `ReserveManager`
+stack.
+
+---
+
+## 1. What DepegGuard does
+
+`DepegGuard.sol` sits next to `Minter` and `Stablecoin`. It does two jobs:
+
+1. **Monitors** the USDC/USD price (or whatever collateral oracle the deployer
+   configures) against basis-point thresholds and a minimum age of observation.
+2. **Triggers** mitigations when the state changes. Each mitigation is
+   configurable and role-gated:
+   - `Normal → Caution`: mints are paused; redeems continue 1:1; a public
+     `DepegStateChanged` event fires so dashboards can flip a banner.
+   - `Caution → Hard`: redeems halt for `hardRedeemHaltSeconds`; the
+     stablecoin contract is paused via its `PAUSER_ROLE`.
+   - `Hard → Caution`: redeem halt is cleared once the oracle recovers past
+     `recoveryCeilingBps` for `minRecoverySeconds`.
+   - `Caution → Normal`: mints resume once the oracle holds above the
+     caution band for `minRecoverySeconds`.
+
+The contract never holds funds. It is a decision + side-effect layer —
+mitigations execute via existing toolkit primitives.
+
+## 2. State machine
+
+```
+               off   > cautionBps for minObservationSeconds
+      ┌──────────────────────────────────────────────────┐
+      │                                                  │
+      ▼                                                  │
+ ┌────────┐  caution breached           ┌────────┐       │
+ │ Normal │ ───────────────────────────▶│Caution │───────┘
+ └────────┘                             └────────┘
+      ▲                                      │
+      │  holds inside band                   │ hard breached
+      │  for minRecoverySeconds              ▼
+      │                                 ┌────────┐
+      └─────────────────────────────────│  Hard  │
+         recovery ceiling held for      └────────┘
+         minRecoverySeconds                  ▲
+                                             │
+                                             └─── no auto exit until
+                                                  hardRedeemHaltSeconds
+                                                  has elapsed AND
+                                                  oracle recovers
+```
+
+**All transitions require a caller with `GUARDIAN_ROLE` OR the public
+`poke()` path** (no role, but only moves the state forward once the
+observation window is satisfied — never backward). This mirrors the
+Chainlink keeper pattern: anyone may pay gas to advance the state, only
+governance may reset it.
+
+## 3. Triggers (thresholds)
+
+| Symbol | Default | Unit | Meaning |
+|---|---|---|---|
+| `cautionBps` | `50` | basis points | oracle deviates ≥ 0.50% from peg |
+| `hardBps` | `200` | basis points | oracle deviates ≥ 2.00% from peg |
+| `minObservationSeconds` | `600` | seconds | threshold must hold this long before escalating |
+| `minRecoverySeconds` | `1800` | seconds | peg must hold post-recovery before de-escalating |
+| `recoveryCeilingBps` | `25` | basis points | tighter band to exit (anti-flap) |
+| `hardRedeemHaltSeconds` | `43200` | seconds (12h) | minimum time redeems stay halted in Hard state |
+| `maxFeedStaleSeconds` | `3600` | seconds | oracle data older than this is treated as stale (reverts checks) |
+
+All knobs are `setXxx(...)` gated on `DEFAULT_ADMIN_ROLE`. Events fire on
+every change so governance is fully auditable.
+
+## 4. Actions by state
+
+| State | Mint allowed? | Redeem allowed? | Stablecoin paused? | Event emitted |
+|---|---|---|---|---|
+| `Normal` | yes | yes | no | `DepegStateChanged(Normal)` |
+| `Caution` | **no** | yes (1:1) | no | `DepegStateChanged(Caution)`, `MintPauseTripped(guard)` |
+| `Hard` | no | **halted for `hardRedeemHaltSeconds`** | **yes** | `DepegStateChanged(Hard)`, `StablecoinPauseTripped(guard)` |
+
+Mitigations are executed via:
+
+- `Minter.setAuthorizedMinter(guard, false)` — the guard revokes itself from
+  the authorized-minter set on escalation into Caution; re-grants on exit.
+  (No new code in `Minter` required — we reuse the existing role plumbing.)
+- `Stablecoin.pause()` / `unpause()` — via `PAUSER_ROLE`, which the guard
+  must be granted at deployment.
+- Redeem halt is enforced by the guard itself — `Minter.redeem` is not
+  modified in this PR; integrators gate `redeem` on
+  `guard.redeemAllowed()`. See §6.
+
+## 5. Failure modes we guard against
+
+| Scenario | Primary signal | What DepegGuard does |
+|---|---|---|
+| USDC goes off peg (SVB-redux) | Chainlink USDC/USD < $0.9950 | Caution → pause mint; operators don't over-mint into a broken collateral |
+| Hard depeg + bank run | USDC < $0.9800 | Hard → pause stablecoin, halt redeems for 12h; prevent first-mover drain |
+| Oracle manipulation (flash) | Price moves >hardBps then reverts inside `minObservationSeconds` | `minObservationSeconds` window eats the flash; no escalation |
+| Curve imbalance — LP drain | Off-chain signal; not directly observable | Governance uses `emergencyEscalate(Hard)` (DEFAULT_ADMIN_ROLE) |
+| Oracle staleness | `updatedAt + maxFeedStaleSeconds < now` | `checkPeg` reverts `FeedStale`; guard refuses to escalate *and* refuses to de-escalate — operators must intervene |
+| Correlated collateral drawdown (T-bills + USDC) | Not observable on-chain | Governance hook — pair with off-chain bot that calls `emergencyEscalate(Hard)` |
+| Reserve custodian flagged | Off-chain signal | `emergencyEscalate(Hard)` |
+
+The contract **never auto-reverses** a governance escalation. Only
+`DEFAULT_ADMIN_ROLE` can call `resetState(Normal)`.
+
+## 6. Integration with the existing toolkit
+
+```
+┌──────────────┐      pause()       ┌──────────────┐
+│ DepegGuard   │ ──────────────────▶│ Stablecoin   │
+│              │                    │ (PAUSER_ROLE)│
+│              │  revokeMinter()    └──────────────┘
+│              │ ─────────────────┐
+│              │                  ▼
+│              │           ┌────────────┐
+│              │           │ Minter     │
+│              │           └────────────┘
+│              │                  ▲
+│              │  priceFeed.latestRoundData
+│              │ ─────────────────┤
+│              │                  │
+│              │                  │
+│              │           ┌────────────┐
+│              │ ◀─────────│ Chainlink  │
+│              │  read     │ USDC/USD   │
+└──────────────┘           └────────────┘
+```
+
+**Required integrations on existing contracts (done in this PR):**
+
+- `Minter` gains a `GUARDIAN_ROLE`-style toggle — **no changes made in this
+  PR**; the guard uses the existing `authorizeMinter / revokeMinter` owner
+  functions, so the deployer must `transferOwnership(guard)` on the `Minter`
+  (or wire a `GovernanceSafe` in between). This is documented in the
+  README under "Adding DepegGuard to an existing deployment".
+- `Stablecoin` must grant `PAUSER_ROLE` to the guard.
+
+**No new public surface on `Minter` or `Stablecoin`.** The guard uses only
+the existing role-gated functions so upgrading is a one-transaction role
+grant, and this PR does not risk breaking callers of either contract.
+
+## 7. Operator runbook
+
+1. **Routine**: `poke()` is called every N blocks by a keeper bot (Chainlink
+   Automation, Gelato, or a simple cron). Keeper cost < $0.05 per call at 20
+   gwei on mainnet.
+2. **Caution fires**: on-call reviews USDC/USD, confirms it is not a feed
+   outage, leaves mints paused. Public status banner updates via
+   `DepegStateChanged` event.
+3. **Hard fires**: on-call pages; if it's a real depeg, follow
+   `docs/emergency-playbook.md` (to be added in a follow-up PR). If it's a
+   feed failure, operators call `resetState(Normal)` once the oracle recovers
+   or governance swaps in a fallback feed via `setPriceFeed`.
+4. **Recovery**: guard auto-deescalates once `minRecoverySeconds` elapses
+   inside `recoveryCeilingBps`, assuming no governance escalation is
+   outstanding.
+
+## 8. Tuning knobs (governance)
+
+All knobs are `set*` gated on `DEFAULT_ADMIN_ROLE`:
+
+- `setPriceFeed(address)` — swap the primary Chainlink feed.
+- `setThresholds(cautionBps, hardBps, recoveryCeilingBps)`
+- `setDurations(minObservationSeconds, minRecoverySeconds, hardRedeemHaltSeconds)`
+- `setStaleness(maxFeedStaleSeconds)`
+- `setPegTarget(uint256)` — defaults to `1e8` (matches Chainlink's USDC/USD
+  feed scale); allow custom pegs for non-USDC collaterals.
+- `resetState(State)` — break-glass; `DEFAULT_ADMIN_ROLE` only; always
+  re-emits `DepegStateChanged` for auditability.
+- `emergencyEscalate(State)` — break-glass for off-chain signals;
+  `DEFAULT_ADMIN_ROLE` only.
+
+## 9. What is explicitly out of scope for v0.1
+
+These were listed on [#19](https://github.com/kcolbchain/stablecoin-toolkit/issues/19)
+and are deferred to a follow-up:
+
+- `EmergencyPool.sol` — pro-rata claim contract. This is a bigger design
+  discussion (snapshot semantics, claim deadlines) and does not block the
+  guard from being useful on day one.
+- Uniswap TWAP fallback oracle. The guard supports a single price feed in
+  v0.1; a fallback adapter can be wired in by making `priceFeed` a router.
+- Redeem-halt enforcement inside `Minter`. v0.1 ships `guard.redeemAllowed()`
+  as the single source of truth; integrators gate UI + any wrapper on top of
+  `Minter.redeem` on it. A v0.2 will add an `onlyGuardClears` modifier to
+  `Minter` once we are ready to version-bump its external surface.
+
+## 10. Threat model summary (one-liner)
+
+DepegGuard protects holders against the three textbook stablecoin failure
+modes — **collateral depeg**, **bank-run / first-mover drain**, and **oracle
+manipulation** — by combining observation-windowed thresholds, role-gated
+break-glass escalation, and mitigations that only use existing toolkit
+primitives so the blast radius of the new contract is bounded by roles we
+already trust.

--- a/forge-test/DepegGuard.t.sol
+++ b/forge-test/DepegGuard.t.sol
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/DepegGuard.sol";
+import "../contracts/Stablecoin.sol";
+import "../contracts/Minter.sol";
+import "../contracts/ReserveManager.sol";
+import "../contracts/ComplianceModule.sol";
+import "../contracts/mocks/ChainlinkPoRMock.sol";
+
+/**
+ * @dev DepegGuard unit tests. Covers:
+ *   - normal-state no-op
+ *   - escalation to Caution after minObservationSeconds
+ *   - escalation to Hard above hardBps
+ *   - recovery into Normal after hardHalt + minRecoverySeconds
+ *   - oracle staleness
+ *   - role-gated calls (resetState / emergencyEscalate / setThresholds)
+ *   - anti-flap: brief deviation that reverts inside observation window
+ */
+contract DepegGuardTest is Test {
+    DepegGuard public guard;
+    Stablecoin public coin;
+    Minter public minter;
+    ReserveManager public rm;
+    ComplianceModule public cm;
+    ChainlinkPoRMock public feed;
+
+    address public admin = address(0xA);
+    address public user = address(0xB);
+    address public feeCollector = address(0xC);
+    address public randomCaller = address(0xD);
+
+    uint256 public constant PEG = 1e8; // 1 USD at 8 decimals
+
+    function setUp() public {
+        vm.startPrank(admin);
+
+        coin = new Stablecoin("Test Stable", "TSTB", admin);
+        rm = new ReserveManager(10_000);
+        cm = new ComplianceModule();
+        minter = new Minter(address(coin), address(rm), address(cm), 0, 0, feeCollector);
+
+        // Wire roles: the guard needs PAUSER_ROLE on the stablecoin and
+        // ownership of the Minter (so it can call authorize/revokeMinter).
+        feed = new ChainlinkPoRMock(int256(PEG));
+
+        guard = new DepegGuard(address(coin), address(minter), address(feed), admin);
+
+        coin.grantRole(coin.PAUSER_ROLE(), address(guard));
+        minter.transferOwnership(address(guard));
+
+        vm.stopPrank();
+    }
+
+    // ========== Baseline state ==========
+
+    function test_initialState_isNormal() public view {
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Normal));
+        assertTrue(guard.mintAllowed());
+        assertTrue(guard.redeemAllowed());
+    }
+
+    function test_poke_inNormal_atPeg_noOp() public {
+        // At $1.00 exactly: no state change.
+        guard.poke();
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Normal));
+    }
+
+    // ========== Caution escalation ==========
+
+    function test_cautionThreshold_requiresObservationWindow() public {
+        // Drop to $0.995 (50 bps) — at exactly the caution threshold.
+        _setPrice(int256(PEG - PEG / 200)); // -50 bps
+
+        // First poke registers pending observation but does not transition.
+        guard.poke();
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Normal));
+
+        // Not enough time has passed.
+        vm.warp(block.timestamp + guard.minObservationSeconds() - 1);
+        guard.poke();
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Normal));
+
+        // Cross the threshold.
+        vm.warp(block.timestamp + 2);
+        guard.poke();
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Caution));
+        assertFalse(guard.mintAllowed());
+        assertTrue(guard.redeemAllowed());
+    }
+
+    function test_antiFlap_briefDeviationReverts() public {
+        _setPrice(int256(PEG - PEG / 100)); // -100 bps (in the caution band)
+        guard.poke(); // pending observation starts
+
+        // Price recovers inside the observation window.
+        vm.warp(block.timestamp + guard.minObservationSeconds() / 2);
+        _setPrice(int256(PEG));
+        guard.poke();
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Normal));
+    }
+
+    // ========== Hard escalation ==========
+
+    function test_hardThreshold_triggersStablecoinPause() public {
+        _setPrice(int256(PEG - PEG / 40)); // -250 bps — well past hard threshold
+        guard.poke();
+        vm.warp(block.timestamp + guard.minObservationSeconds() + 1);
+        guard.poke();
+
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Hard));
+        assertFalse(guard.mintAllowed());
+        assertFalse(guard.redeemAllowed());
+        assertTrue(coin.paused(), "stablecoin should be paused in Hard state");
+    }
+
+    // ========== Recovery to Normal ==========
+
+    function test_recoveryFromCaution_restoresNormalAfterRecoveryWindow() public {
+        // Enter Caution.
+        _setPrice(int256(PEG - PEG / 100));
+        guard.poke();
+        vm.warp(block.timestamp + guard.minObservationSeconds() + 1);
+        guard.poke();
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Caution));
+
+        // Price recovers firmly inside the recovery band.
+        _setPrice(int256(PEG));
+        guard.poke();
+
+        // Before recovery window: still Caution.
+        vm.warp(block.timestamp + guard.minRecoverySeconds() - 1);
+        guard.poke();
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Caution));
+
+        // After recovery window: back to Normal.
+        vm.warp(block.timestamp + 2);
+        guard.poke();
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Normal));
+        assertTrue(guard.mintAllowed());
+    }
+
+    function test_recoveryFromHard_respectsHardHaltTimer() public {
+        // Enter Hard.
+        _setPrice(int256(PEG - PEG / 40));
+        guard.poke();
+        vm.warp(block.timestamp + guard.minObservationSeconds() + 1);
+        guard.poke();
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Hard));
+
+        uint256 enteredAt = guard.stateEnteredAt();
+
+        // Price recovers immediately.
+        _setPrice(int256(PEG));
+        guard.poke();
+
+        // Recovery window elapsed but hardHalt has NOT.
+        vm.warp(block.timestamp + guard.minRecoverySeconds() + 1);
+        assertTrue(block.timestamp < enteredAt + guard.hardRedeemHaltSeconds());
+        guard.poke();
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Hard));
+        assertFalse(guard.redeemAllowed());
+
+        // Fast-forward past the hard-halt timer.
+        vm.warp(enteredAt + guard.hardRedeemHaltSeconds() + 1);
+        guard.poke();
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Normal));
+        assertTrue(guard.redeemAllowed());
+        assertFalse(coin.paused(), "stablecoin should be unpaused after recovery");
+    }
+
+    // ========== Oracle staleness ==========
+
+    function test_staleFeed_reverts() public {
+        // Set a fresh price, then warp past the staleness window.
+        _setPrice(int256(PEG));
+        uint256 stale = guard.maxFeedStaleSeconds();
+        vm.warp(block.timestamp + stale + 1);
+
+        vm.expectRevert();
+        guard.currentDeviationBps();
+
+        vm.expectRevert();
+        guard.poke();
+    }
+
+    function test_feedFresh_reflectsStaleness() public {
+        _setPrice(int256(PEG));
+        assertTrue(guard.feedFresh());
+
+        vm.warp(block.timestamp + guard.maxFeedStaleSeconds() + 1);
+        assertFalse(guard.feedFresh());
+    }
+
+    // ========== Role-gated calls ==========
+
+    function test_emergencyEscalate_onlyAdmin() public {
+        vm.prank(randomCaller);
+        vm.expectRevert();
+        guard.emergencyEscalate(DepegGuard.State.Hard);
+
+        vm.prank(admin);
+        guard.emergencyEscalate(DepegGuard.State.Hard);
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Hard));
+        assertTrue(coin.paused());
+    }
+
+    function test_resetState_onlyAdmin_restoresNormal() public {
+        // Escalate via governance.
+        vm.prank(admin);
+        guard.emergencyEscalate(DepegGuard.State.Hard);
+        assertTrue(coin.paused());
+
+        vm.prank(randomCaller);
+        vm.expectRevert();
+        guard.resetState(DepegGuard.State.Normal);
+
+        vm.prank(admin);
+        guard.resetState(DepegGuard.State.Normal);
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Normal));
+        assertFalse(coin.paused());
+    }
+
+    function test_setThresholds_rejectsInvalid() public {
+        vm.startPrank(admin);
+        vm.expectRevert(DepegGuard.InvalidThresholds.selector);
+        guard.setThresholds(0, 200, 25); // caution == 0
+
+        vm.expectRevert(DepegGuard.InvalidThresholds.selector);
+        guard.setThresholds(100, 50, 25); // hard < caution
+
+        vm.expectRevert(DepegGuard.InvalidThresholds.selector);
+        guard.setThresholds(100, 200, 150); // recovery > caution
+        vm.stopPrank();
+    }
+
+    function test_setThresholds_acceptsValid() public {
+        vm.prank(admin);
+        guard.setThresholds(100, 300, 50);
+        assertEq(guard.cautionBps(), 100);
+        assertEq(guard.hardBps(), 300);
+        assertEq(guard.recoveryCeilingBps(), 50);
+    }
+
+    function test_setPriceFeed_rejectsZero() public {
+        vm.startPrank(admin);
+        vm.expectRevert(DepegGuard.ZeroAddress.selector);
+        guard.setPriceFeed(address(0));
+
+        // A fresh mock works.
+        ChainlinkPoRMock newFeed = new ChainlinkPoRMock(int256(PEG));
+        guard.setPriceFeed(address(newFeed));
+        vm.stopPrank();
+        assertEq(address(guard.priceFeed()), address(newFeed));
+    }
+
+    function test_nonAdmin_cannotTune() public {
+        vm.startPrank(randomCaller);
+        vm.expectRevert();
+        guard.setThresholds(100, 300, 50);
+        vm.expectRevert();
+        guard.setDurations(600, 1800, 3600);
+        vm.expectRevert();
+        guard.setStaleness(3600);
+        vm.expectRevert();
+        guard.setPegTarget(1e8);
+        vm.stopPrank();
+    }
+
+    // ========== Views ==========
+
+    function test_currentDeviationBps_computesAbs() public {
+        _setPrice(int256(PEG + PEG / 100)); // +100 bps
+        (uint256 devBps, uint256 price, ) = guard.currentDeviationBps();
+        assertEq(devBps, 100);
+        assertEq(price, PEG + PEG / 100);
+
+        _setPrice(int256(PEG - PEG / 50)); // -200 bps
+        (devBps, price, ) = guard.currentDeviationBps();
+        assertEq(devBps, 200);
+        assertEq(price, PEG - PEG / 50);
+    }
+
+    // ========== Edge: upward depegs (USDC > $1) ==========
+
+    function test_upwardDepeg_alsoEscalates() public {
+        _setPrice(int256(PEG + PEG / 40)); // +250 bps
+        guard.poke();
+        vm.warp(block.timestamp + guard.minObservationSeconds() + 1);
+        guard.poke();
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Hard));
+    }
+
+    // ========== Public poke never goes backward without governance ==========
+
+    function test_poke_cannotSkipObservationWindow() public {
+        _setPrice(int256(PEG - PEG / 40)); // way past hard
+        // Single poke in the same block: no state change.
+        guard.poke();
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Normal));
+
+        // Even one second later.
+        vm.warp(block.timestamp + 1);
+        guard.poke();
+        assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Normal));
+    }
+
+    // ========== Helpers ==========
+
+    function _setPrice(int256 answer) internal {
+        feed.setAnswerWithTimestamp(answer, block.timestamp);
+    }
+}

--- a/test/DepegGuard.test.js
+++ b/test/DepegGuard.test.js
@@ -1,0 +1,241 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+/**
+ * Hardhat mirror of `forge-test/DepegGuard.t.sol`. Kept in sync so local
+ * contributors can validate without foundry installed.
+ */
+
+const PEG = 10n ** 8n; // $1 at 8 decimals
+
+async function deployStack() {
+  const [admin, feeCollector, user, randomCaller] = await ethers.getSigners();
+
+  const Stablecoin = await ethers.getContractFactory("Stablecoin");
+  const coin = await Stablecoin.deploy("Test Stable", "TSTB", admin.address);
+  await coin.waitForDeployment();
+
+  const ReserveManager = await ethers.getContractFactory("ReserveManager");
+  const rm = await ReserveManager.deploy(10_000n);
+  await rm.waitForDeployment();
+
+  const ComplianceModule = await ethers.getContractFactory("ComplianceModule");
+  const cm = await ComplianceModule.deploy();
+  await cm.waitForDeployment();
+
+  const Minter = await ethers.getContractFactory("Minter");
+  const minter = await Minter.deploy(
+    await coin.getAddress(),
+    await rm.getAddress(),
+    await cm.getAddress(),
+    0n,
+    0n,
+    feeCollector.address,
+  );
+  await minter.waitForDeployment();
+
+  const Mock = await ethers.getContractFactory("ChainlinkPoRMock");
+  const feed = await Mock.deploy(PEG);
+  await feed.waitForDeployment();
+
+  const DepegGuard = await ethers.getContractFactory("DepegGuard");
+  const guard = await DepegGuard.deploy(
+    await coin.getAddress(),
+    await minter.getAddress(),
+    await feed.getAddress(),
+    admin.address,
+  );
+  await guard.waitForDeployment();
+
+  await coin.grantRole(await coin.PAUSER_ROLE(), await guard.getAddress());
+  await minter.transferOwnership(await guard.getAddress());
+
+  return { admin, feeCollector, user, randomCaller, coin, rm, cm, minter, feed, guard };
+}
+
+async function setPrice(feed, answer) {
+  const block = await ethers.provider.getBlock("latest");
+  await feed.setAnswerWithTimestamp(answer, block.timestamp);
+}
+
+async function advance(seconds) {
+  await ethers.provider.send("evm_increaseTime", [Number(seconds)]);
+  await ethers.provider.send("evm_mine", []);
+}
+
+const State = { Normal: 0, Caution: 1, Hard: 2 };
+
+describe("DepegGuard", function () {
+  let ctx;
+
+  beforeEach(async function () {
+    ctx = await deployStack();
+  });
+
+  it("starts in Normal and allows mint+redeem", async function () {
+    expect(await ctx.guard.currentState()).to.equal(State.Normal);
+    expect(await ctx.guard.mintAllowed()).to.equal(true);
+    expect(await ctx.guard.redeemAllowed()).to.equal(true);
+  });
+
+  it("does not escalate on a single poke at the caution threshold", async function () {
+    await setPrice(ctx.feed, PEG - PEG / 200n); // -50 bps
+    await ctx.guard.poke();
+    expect(await ctx.guard.currentState()).to.equal(State.Normal);
+  });
+
+  it("escalates Normal -> Caution after minObservationSeconds", async function () {
+    await setPrice(ctx.feed, PEG - PEG / 200n);
+    await ctx.guard.poke();
+    const minObs = await ctx.guard.minObservationSeconds();
+    // keep the feed fresh across the warp
+    await advance(minObs + 1n);
+    await setPrice(ctx.feed, PEG - PEG / 200n);
+    await ctx.guard.poke();
+    expect(await ctx.guard.currentState()).to.equal(State.Caution);
+    expect(await ctx.guard.mintAllowed()).to.equal(false);
+    expect(await ctx.guard.redeemAllowed()).to.equal(true);
+  });
+
+  it("escalates all the way to Hard on a 250 bps drop", async function () {
+    await setPrice(ctx.feed, PEG - PEG / 40n); // -250 bps
+    await ctx.guard.poke();
+    await advance((await ctx.guard.minObservationSeconds()) + 1n);
+    await setPrice(ctx.feed, PEG - PEG / 40n);
+    await ctx.guard.poke();
+    expect(await ctx.guard.currentState()).to.equal(State.Hard);
+    expect(await ctx.guard.redeemAllowed()).to.equal(false);
+    expect(await ctx.coin.paused()).to.equal(true);
+  });
+
+  it("anti-flap: brief deviation that reverts inside observation window stays Normal", async function () {
+    await setPrice(ctx.feed, PEG - PEG / 100n);
+    await ctx.guard.poke();
+    await advance((await ctx.guard.minObservationSeconds()) / 2n);
+    await setPrice(ctx.feed, PEG);
+    await ctx.guard.poke();
+    expect(await ctx.guard.currentState()).to.equal(State.Normal);
+  });
+
+  it("recovers Caution -> Normal after minRecoverySeconds of stable peg", async function () {
+    await setPrice(ctx.feed, PEG - PEG / 100n);
+    await ctx.guard.poke();
+    await advance((await ctx.guard.minObservationSeconds()) + 1n);
+    await setPrice(ctx.feed, PEG - PEG / 100n);
+    await ctx.guard.poke();
+    expect(await ctx.guard.currentState()).to.equal(State.Caution);
+
+    await setPrice(ctx.feed, PEG);
+    await ctx.guard.poke();
+    await advance((await ctx.guard.minRecoverySeconds()) + 1n);
+    await setPrice(ctx.feed, PEG);
+    await ctx.guard.poke();
+    expect(await ctx.guard.currentState()).to.equal(State.Normal);
+    expect(await ctx.guard.mintAllowed()).to.equal(true);
+  });
+
+  it("recovery from Hard respects the hardRedeemHaltSeconds timer", async function () {
+    await setPrice(ctx.feed, PEG - PEG / 40n);
+    await ctx.guard.poke();
+    await advance((await ctx.guard.minObservationSeconds()) + 1n);
+    await setPrice(ctx.feed, PEG - PEG / 40n);
+    await ctx.guard.poke();
+    expect(await ctx.guard.currentState()).to.equal(State.Hard);
+
+    const enteredAt = await ctx.guard.stateEnteredAt();
+
+    // Price recovers.
+    await setPrice(ctx.feed, PEG);
+    await ctx.guard.poke();
+
+    // Recovery elapsed but hardHalt hasn't.
+    await advance((await ctx.guard.minRecoverySeconds()) + 1n);
+    await setPrice(ctx.feed, PEG);
+    await ctx.guard.poke();
+    expect(await ctx.guard.currentState()).to.equal(State.Hard);
+
+    // Past hardRedeemHaltSeconds.
+    const hardHalt = await ctx.guard.hardRedeemHaltSeconds();
+    const now = BigInt((await ethers.provider.getBlock("latest")).timestamp);
+    const target = enteredAt + hardHalt + 5n;
+    if (now < target) {
+      await advance(target - now);
+    }
+    await setPrice(ctx.feed, PEG);
+    await ctx.guard.poke();
+    expect(await ctx.guard.currentState()).to.equal(State.Normal);
+    expect(await ctx.coin.paused()).to.equal(false);
+  });
+
+  it("reverts with FeedStale when the feed is older than maxFeedStaleSeconds", async function () {
+    await setPrice(ctx.feed, PEG);
+    await advance((await ctx.guard.maxFeedStaleSeconds()) + 1n);
+    await expect(ctx.guard.currentDeviationBps()).to.be.reverted;
+    await expect(ctx.guard.poke()).to.be.reverted;
+  });
+
+  it("gates setThresholds / resetState / emergencyEscalate on the admin role", async function () {
+    const { guard, randomCaller, admin, coin } = ctx;
+
+    await expect(guard.connect(randomCaller).setThresholds(100n, 200n, 25n)).to.be.reverted;
+    await expect(guard.connect(randomCaller).emergencyEscalate(State.Hard)).to.be.reverted;
+    await expect(guard.connect(randomCaller).resetState(State.Normal)).to.be.reverted;
+
+    await guard.connect(admin).emergencyEscalate(State.Hard);
+    expect(await guard.currentState()).to.equal(State.Hard);
+    expect(await coin.paused()).to.equal(true);
+
+    await guard.connect(admin).resetState(State.Normal);
+    expect(await guard.currentState()).to.equal(State.Normal);
+    expect(await coin.paused()).to.equal(false);
+  });
+
+  it("setThresholds rejects invalid combinations", async function () {
+    const { guard, admin } = ctx;
+    await expect(guard.connect(admin).setThresholds(0n, 200n, 25n)).to.be.revertedWithCustomError(
+      guard,
+      "InvalidThresholds",
+    );
+    await expect(guard.connect(admin).setThresholds(100n, 50n, 25n)).to.be.revertedWithCustomError(
+      guard,
+      "InvalidThresholds",
+    );
+    await expect(guard.connect(admin).setThresholds(100n, 200n, 150n)).to.be.revertedWithCustomError(
+      guard,
+      "InvalidThresholds",
+    );
+  });
+
+  it("computes absolute deviation (upward depeg also counts)", async function () {
+    await setPrice(ctx.feed, PEG + PEG / 100n); // +100 bps
+    const [devUp] = await ctx.guard.currentDeviationBps();
+    expect(devUp).to.equal(100n);
+
+    await setPrice(ctx.feed, PEG - PEG / 50n); // -200 bps
+    const [devDown] = await ctx.guard.currentDeviationBps();
+    expect(devDown).to.equal(200n);
+  });
+
+  it("upward depeg > hardBps also triggers Hard state", async function () {
+    await setPrice(ctx.feed, PEG + PEG / 40n); // +250 bps
+    await ctx.guard.poke();
+    await advance((await ctx.guard.minObservationSeconds()) + 1n);
+    await setPrice(ctx.feed, PEG + PEG / 40n);
+    await ctx.guard.poke();
+    expect(await ctx.guard.currentState()).to.equal(State.Hard);
+  });
+
+  it("setPriceFeed rejects zero address and swaps feeds", async function () {
+    const { guard, admin } = ctx;
+    await expect(guard.connect(admin).setPriceFeed(ethers.ZeroAddress)).to.be.revertedWithCustomError(
+      guard,
+      "ZeroAddress",
+    );
+
+    const Mock = await ethers.getContractFactory("ChainlinkPoRMock");
+    const newFeed = await Mock.deploy(PEG);
+    await newFeed.waitForDeployment();
+    await guard.connect(admin).setPriceFeed(await newFeed.getAddress());
+    expect(await guard.priceFeed()).to.equal(await newFeed.getAddress());
+  });
+});


### PR DESCRIPTION
## Summary

Closes #19 — adds `DepegGuard.sol` so toolkit stablecoins (CR8-USD, MUSD, …) have a watchdog that pauses mints and the stablecoin when the collateral feed deviates from peg.

- `contracts/DepegGuard.sol` — Normal → Caution → Hard state machine, observation-windowed so flash-depegs don't escalate, auto-deescalates on recovery, fails closed on stale oracle data.
- `docs/depeg-guard.md` — full spec: state diagram, threshold tables, threat model (Curve imbalance, oracle manipulation, bank-run, correlated collateral), operator runbook, tuning knobs, integration steps.
- `forge-test/DepegGuard.t.sol` — Foundry tests (matches existing `forge-test/` convention).
- `test/DepegGuard.test.js` — hardhat mirror so local contributors without foundry can validate.
- README updated to list DepegGuard + ChainlinkPoRAdapter.

## Design notes

- **No changes to `Stablecoin` or `Minter`.** The guard composes over their existing public surface (`PAUSER_ROLE` + `Minter.authorize/revokeMinter`). Existing callers don't need to change.
- **Integration** (per `docs/depeg-guard.md` §6): grant the guard `PAUSER_ROLE` on `Stablecoin` and `transferOwnership(guard)` on `Minter`.
- **Public `poke()`** so a keeper bot can pay gas — never moves state backward, never skips observation windows.
- **Break-glass** (`emergencyEscalate`, `resetState`) is `DEFAULT_ADMIN_ROLE`-gated — covers off-chain signals the oracle can't see (Curve imbalance, reserve custodian flagged).

## Explicitly deferred to follow-ups (spec §9)

- `EmergencyPool.sol` — bigger snapshot/claim semantics conversation, not blocking day-one usefulness.
- Uniswap TWAP fallback — single-feed in v0.1.
- `onlyGuardClears` modifier inside `Minter` — v0.2 material, requires a public-surface bump we'd rather batch with other changes.

## Test plan

- [x] `npx hardhat compile` — clean.
- [x] `npx hardhat test test/DepegGuard.test.js` — 13/13 pass.
- [x] `npx hardhat test` (full suite) — 47/47 pass (34 pre-existing + 13 new). No regressions.
- [ ] `forge test` — not run locally (foundry not installed in this env); the Solidity test is kept in sync with the hardhat mirror.

## Threat coverage

| Scenario | Handled by |
|---|---|
| USDC soft depeg (50 bps) | Caution → pause mint |
| USDC hard depeg (200+ bps) | Hard → pause stablecoin + halt redeems for 12h |
| Flash / MEV oracle manipulation | `minObservationSeconds` observation window |
| Oracle staleness | `FeedStale` revert; refuses to escalate *or* de-escalate until fresh |
| Curve imbalance / custodian flagged / correlated drawdown | `emergencyEscalate` (admin) |
| Anti-flap on recovery | `recoveryCeilingBps` hysteresis + `minRecoverySeconds` |