### PR TITLE
fix: pin @openzeppelin/contracts to 5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "deploy:local": "hardhat run scripts/deploy.js --network localhost"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^5.0.0"
+    "@openzeppelin/contracts": "5.0.2"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",


### PR DESCRIPTION
## Summary

`package.json` declared `@openzeppelin/contracts: ^5.0.0`. On a clean install that resolves to `5.6.1`, which emits Cancun opcodes (`mcopy`). The repo's `hardhat.config.js` and `foundry.toml` both target `solc 0.8.24` (Paris), so `npx hardhat compile` failed for new contributors. Pin to exact `5.0.2` — smallest blast radius, no solc-version bump required.

## Local validation

```
$ npm install
$ npx hardhat compile
Compiled 33 Solidity files successfully (evm target: paris).

$ npx hardhat test
  47 passing (5s)
```

No lockfile committed — matches the existing repo convention (`package-lock.json` is not tracked).

closes #22

---

Contributed by kcolbchain (https://kcolbchain.com) · https://abhishekkrishna.com