### PR TITLE
ci: add forge install + forge test workflow

### DIFF
--- a/.github/workflows/forge.yml
+++ b/.github/workflows/forge.yml
@@ -1,0 +1,38 @@
+name: forge
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: forge test
+    runs-on: ubuntu-latest
+    env:
+      # foundry.toml pins libs=["node_modules"] (for @openzeppelin).
+      # Forge-std installs to lib/ by default; extend FOUNDRY_LIBS so
+      # both resolve without modifying foundry.toml.
+      FOUNDRY_LIBS: '["node_modules", "lib"]'
+      FOUNDRY_TEST: forge-test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install npm deps (@openzeppelin/contracts)
+        run: npm install
+
+      - name: Install forge-std
+        run: forge install foundry-rs/forge-std --no-commit
+
+      - name: Forge test
+        run: forge test -vvv


### PR DESCRIPTION
## Summary

Adds `.github/workflows/forge.yml` so the existing `forge-test/*.sol` suite (Stablecoin, Minter, ReserveManager, ComplianceModule, DepegGuard — 5 files) runs on push/PR. First workflow in this repo.

- `foundry-rs/foundry-toolchain@v1` (stable).
- `npm install` to pull `@openzeppelin/contracts` into `node_modules`, which `foundry.toml` already has as a lib path.
- `forge install foundry-rs/forge-std --no-commit` — only missing dep.
- `forge test -vvv`.

`FOUNDRY_LIBS` is extended via env to include both the existing `node_modules` path (for OZ) and `lib/` (where `forge install` puts forge-std), keeping `foundry.toml` untouched. `FOUNDRY_TEST=forge-test` because the repo's test dir is `forge-test/` rather than the Foundry default `test/`.

## Local validation

The `forge` binary is not installed in the operator's sandbox, and piping `foundry.paradigm.xyz | bash` is sandbox-blocked (cf. `reports/frontier/ship-hanzoai.md`). Validation happens on this CI job. Merged on green.

closes #23

---

Contributed by kcolbchain (https://kcolbchain.com) · https://abhishekkrishna.com