### PR TITLE
ci: drop --no-commit flag from forge install

### DIFF
--- a/.github/workflows/forge.yml
+++ b/.github/workflows/forge.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm install
 
       - name: Install forge-std
-        run: forge install foundry-rs/forge-std --no-commit
+        run: forge install foundry-rs/forge-std
 
       - name: Forge test
         run: forge test -vvv


### PR DESCRIPTION
## Summary

The `forge` CLI (modern Foundry) removed `--no-commit` — not-committing is now the default, and `--commit` opts in. The forge workflow added in #29 was failing at the install step with:

```
error: unexpected argument '--no-commit' found
  tip: a similar argument exists: '--commit'
```

Drops the flag.

Follow-up hotfix to #29. No scope expansion — only this one-line change.

---

Contributed by kcolbchain (https://kcolbchain.com) · https://abhishekkrishna.com