### PR TITLE
test(forge): refresh feed timestamp before hardHalt-elapsed poke

### DIFF
--- a/forge-test/DepegGuard.t.sol
+++ b/forge-test/DepegGuard.t.sol
@@ -163,8 +163,11 @@ contract DepegGuardTest is Test {
         assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Hard));
         assertFalse(guard.redeemAllowed());
 
-        // Fast-forward past the hard-halt timer.
+        // Fast-forward past the hard-halt timer. Re-publish the feed
+        // timestamp so it's not stale after the warp (mirrors the hardhat
+        // suite's equivalent step).
         vm.warp(enteredAt + guard.hardRedeemHaltSeconds() + 1);
+        _setPrice(int256(PEG));
         guard.poke();
         assertEq(uint256(guard.currentState()), uint256(DepegGuard.State.Normal));
         assertTrue(guard.redeemAllowed());


### PR DESCRIPTION
## Summary

`test_recoveryFromHard_respectsHardHaltTimer` warps `block.timestamp` forward by 12h+1 to cross `hardRedeemHaltSeconds`, but leaves the mock feed's `updatedAt` back at the Hard-state entry point. That's ~43,200s old against the 3,600s `maxFeedStaleSeconds` window, so `poke()` reverts `FeedStale(…)` before it can demote the state back to Normal. Surfaced by the forge CI added in #29 and unblocked by the flag fix in #30.

Fix: re-publish the peg price after the warp, mirroring what the hardhat mirror (`test/DepegGuard.test.js`) does at the equivalent step.

## Scope

One test function. No contract changes. No other test modified.

closes #31

---

Contributed by kcolbchain (https://kcolbchain.com) · https://abhishekkrishna.com