### PR TITLE
Docs: explain DepegGuard peg maintenance flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,74 @@ Built on learnings from real stablecoin deployments. Production-grade Solidity c
 - **Multi-geography** — configurable per jurisdiction (see `config/geographies/`)
 - **Role-based access** — MINTER, PAUSER, BLACKLISTER roles via OpenZeppelin AccessControl
 
+## Peg maintenance
+
+`DepegGuard` is the toolkit's peg-monitoring circuit breaker. It reads a Chainlink-style collateral price feed through [`ChainlinkPoRAdapter.sol`](contracts/ChainlinkPoRAdapter.sol) and applies a small state machine before operators keep minting into a stressed market.
+
+Ground truth:
+- Contract: [`contracts/DepegGuard.sol`](contracts/DepegGuard.sol)
+- Tests: [`forge-test/DepegGuard.t.sol`](forge-test/DepegGuard.t.sol)
+- Full design notes: [`docs/depeg-guard.md`](docs/depeg-guard.md)
+
+```text
+                deviation >= cautionBps for minObservationSeconds
+Normal  -------------------------------------------------------->  Caution
+  ^                                                                  |
+  |                                                                  | deviation >= hardBps
+  | recovery inside recoveryCeilingBps                               v
+  | for minRecoverySeconds                                         Hard
+  +------------------------------------------------------------------+
+      after minRecoverySeconds, and for Hard only after hardRedeemHaltSeconds
+```
+
+### What it watches
+
+- **Oracle source:** a Chainlink-compatible feed exposed via `latestRoundData()`
+- **Default peg target:** `1e8` (`$1.00` at 8 decimals)
+- **Deviation logic:** absolute distance from the peg, measured in basis points
+- **Freshness:** feed data older than `maxFeedStaleSeconds` is treated as stale and `poke()` reverts
+
+### Default thresholds
+
+| Parameter | Default | Meaning |
+|----------|---------|---------|
+| `cautionBps` | `50` | Enter Caution at **0.50%** deviation |
+| `hardBps` | `200` | Enter Hard at **2.00%** deviation |
+| `recoveryCeilingBps` | `25` | Price must recover inside **0.25%** band to de-escalate |
+| `minObservationSeconds` | `600` | Deviation must persist for **10 min** before escalation |
+| `minRecoverySeconds` | `1800` | Recovery must persist for **30 min** before de-escalation |
+| `hardRedeemHaltSeconds` | `43200` | Hard state keeps redemptions halted for at least **12h** |
+| `maxFeedStaleSeconds` | `3600` | Feed older than **1h** is unusable |
+
+### What happens when the guard trips
+
+- **Normal**
+  - `mintAllowed()` returns `true`
+  - `redeemAllowed()` returns `true`
+- **Caution**
+  - minting is disabled (`mintAllowed() == false`)
+  - redemptions continue
+  - the stablecoin itself is **not** paused
+- **Hard**
+  - minting remains disabled
+  - `redeemAllowed()` stays `false` until `hardRedeemHaltSeconds` has elapsed
+  - the stablecoin is paused via `PAUSER_ROLE`
+
+### How to tune it
+
+Governance/admin can reconfigure the guard with:
+- `setThresholds(cautionBps, hardBps, recoveryCeilingBps)`
+- `setDurations(minObservationSeconds, minRecoverySeconds, hardRedeemHaltSeconds)`
+- `setStaleness(maxFeedStaleSeconds)`
+- `setPegTarget(pegTarget)`
+- `setPriceFeed(feed)`
+
+### Local testing / bypassing the guard
+
+For local tests, keep the system in `Normal` by publishing a fresh at-peg price to the mock feed before calling `poke()`. The Foundry suite does this with `ChainlinkPoRMock.setAnswerWithTimestamp(...)` in [`forge-test/DepegGuard.t.sol`](forge-test/DepegGuard.t.sol).
+
+If you intentionally trip the guard during testing, an admin can restore the happy path with `resetState(DepegGuard.State.Normal)` after updating the mock feed.
+
 ## Getting Started
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a new **Peg maintenance** section to the README to document how `DepegGuard` monitors collateral price deviations and responds when thresholds are breached.

## What’s included

- Added a self-contained `## Peg maintenance` section to `README.md`
- Linked the implementation and test sources:
  - `contracts/DepegGuard.sol`
  - `forge-test/DepegGuard.t.sol`
- Documented:
  - what the guard watches
  - default thresholds and timing parameters
  - behavior in `Normal`, `Caution`, and `Hard`
  - admin tuning hooks
  - local testing / reset guidance
- Included a simple ASCII state diagram

## Why this matters

The repository already includes `DepegGuard`, but the README previously only mentioned it briefly. This change makes the peg-defense flow easier for new contributors and integrators to understand without reading the contract first.

## Scope

- Documentation only
- No contract or test changes

## Related issue

Closes #26