### PR TITLE
Add Chainlink reserve proof

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Built on learnings from real stablecoin deployments. Production-grade Solidity c
 
 - **ERC-20 stablecoin** with mint/burn, pausable, blacklistable, EIP-2612 permit
 - **Reserve manager** — multi-asset reserve tracking, on-chain proof of reserves, ratio enforcement
+- **Chainlink reserve proof** — compares stablecoin supply against a Proof of Reserves feed with backed / underbacked / overshoot status
 - **Compliance module** — KYC status per address, geography-based transfer restrictions, transaction limits
 - **Minting gateway** — compliance-checked minting, redemption queue, fee management
 - **Depeg defence** — `DepegGuard` state machine monitors the collateral price feed and pauses mints / stablecoin on threshold breaches; see [`docs/depeg-guard.md`](docs/depeg-guard.md)
@@ -70,10 +71,23 @@ config/geographies/
 |----------|-------------|
 | `Stablecoin.sol` | Core ERC-20 with mint/burn, pause, blacklist, permit |
 | `ReserveManager.sol` | Multi-asset reserve tracking and proof of reserves |
+| `ChainlinkReserveProof.sol` | Read-only reserve proof comparing `totalSupply()` with a Chainlink PoR feed |
 | `ComplianceModule.sol` | KYC, geography restrictions, transaction limits |
 | `Minter.sol` | Gateway — compliance + reserve checks before mint/redeem |
 | `DepegGuard.sol` | Depeg-defence watchdog — Normal/Caution/Hard state machine, pauses mints + stablecoin on threshold breaches. Spec: [`docs/depeg-guard.md`](docs/depeg-guard.md) |
 | `ChainlinkPoRAdapter.sol` | Adapter for Chainlink Proof of Reserves feeds |
+
+## Reserve Proof
+
+`ChainlinkReserveProof` verifies whether the minted supply is fully backed by a
+Chainlink Proof of Reserves feed. It exposes:
+
+- `isFullyBacked()` for simple status checks.
+- `reserveStatus()` for `Underbacked`, `Backed`, or `Overshoot`.
+- `checkReserves()` to emit `ReserveCheckPerformed(supply, reserves, backed)`.
+
+See [`docs/reserve-proof.md`](docs/reserve-proof.md) for deployment inputs,
+staleness checks, and operational guidance.
 
 ## Contributing
 

--- a/contracts/ChainlinkReserveProof.sol
+++ b/contracts/ChainlinkReserveProof.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "./interfaces/IAggregatorV3.sol";
+
+/**
+ * @title ChainlinkReserveProof
+ * @notice Verifies stablecoin supply against a Chainlink Proof of Reserves feed.
+ * @dev Feed answers are scaled to the stablecoin decimals before comparison.
+ */
+contract ChainlinkReserveProof {
+    enum ReserveStatus {
+        Underbacked,
+        Backed,
+        Overshoot
+    }
+
+    IERC20Metadata public immutable stablecoin;
+    AggregatorV3Interface public immutable reserveFeed;
+    uint256 public immutable maxFeedAge;
+
+    event ReserveCheckPerformed(uint256 supply, uint256 reserves, bool backed);
+
+    error InvalidStablecoin();
+    error InvalidReserveFeed();
+    error InvalidReserveAnswer();
+    error StaleReserveFeed(uint256 updatedAt);
+    error IncompleteReserveRound(uint80 roundId, uint80 answeredInRound);
+
+    constructor(address stablecoin_, address reserveFeed_, uint256 maxFeedAge_) {
+        if (stablecoin_ == address(0)) revert InvalidStablecoin();
+        if (reserveFeed_ == address(0)) revert InvalidReserveFeed();
+
+        stablecoin = IERC20Metadata(stablecoin_);
+        reserveFeed = AggregatorV3Interface(reserveFeed_);
+        maxFeedAge = maxFeedAge_;
+    }
+
+    /**
+     * @notice Returns latest reserves in stablecoin base units.
+     */
+    function latestReserves() public view returns (uint256 reserves, uint256 updatedAt) {
+        (uint80 roundId, int256 answer,, uint256 feedUpdatedAt, uint80 answeredInRound) =
+            reserveFeed.latestRoundData();
+
+        if (answer < 0) revert InvalidReserveAnswer();
+        if (feedUpdatedAt == 0) revert InvalidReserveAnswer();
+        if (answeredInRound < roundId) revert IncompleteReserveRound(roundId, answeredInRound);
+        if (maxFeedAge != 0 && block.timestamp - feedUpdatedAt > maxFeedAge) {
+            revert StaleReserveFeed(feedUpdatedAt);
+        }
+
+        return (
+            _scaleAmount(uint256(answer), reserveFeed.decimals(), stablecoin.decimals()),
+            feedUpdatedAt
+        );
+    }
+
+    function reserveStatus() public view returns (ReserveStatus status) {
+        (uint256 reserves,) = latestReserves();
+        uint256 supply = stablecoin.totalSupply();
+
+        if (reserves < supply) return ReserveStatus.Underbacked;
+        if (reserves == supply) return ReserveStatus.Backed;
+        return ReserveStatus.Overshoot;
+    }
+
+    function isFullyBacked() public view returns (bool) {
+        return reserveStatus() != ReserveStatus.Underbacked;
+    }
+
+    /**
+     * @notice Performs a reserve check and emits the observed supply/reserve pair.
+     */
+    function checkReserves() external returns (ReserveStatus status, bool backed) {
+        (uint256 reserves,) = latestReserves();
+        uint256 supply = stablecoin.totalSupply();
+
+        if (reserves < supply) status = ReserveStatus.Underbacked;
+        else if (reserves == supply) status = ReserveStatus.Backed;
+        else status = ReserveStatus.Overshoot;
+
+        backed = status != ReserveStatus.Underbacked;
+        emit ReserveCheckPerformed(supply, reserves, backed);
+    }
+
+    function _scaleAmount(uint256 amount, uint8 fromDecimals, uint8 toDecimals)
+        internal
+        pure
+        returns (uint256)
+    {
+        if (fromDecimals == toDecimals) return amount;
+        if (fromDecimals > toDecimals) return amount / (10 ** (fromDecimals - toDecimals));
+        return amount * (10 ** (toDecimals - fromDecimals));
+    }
+}

--- a/docs/reserve-proof.md
+++ b/docs/reserve-proof.md
@@ -1,0 +1,38 @@
+# Chainlink Reserve Proof
+
+`ChainlinkReserveProof` compares the live stablecoin `totalSupply()` against a
+Chainlink Proof of Reserves feed. It is designed for read-heavy monitoring and
+for on-chain status checks that do not require trusting issuer attestations.
+
+## Flow
+
+1. Read the latest reserve value from the configured Chainlink
+   `AggregatorV3Interface` feed.
+2. Scale the feed answer to the stablecoin decimal precision.
+3. Compare scaled reserves with `totalSupply()`.
+4. Return one of three statuses:
+   - `Underbacked`: reserves are lower than supply.
+   - `Backed`: reserves exactly match supply.
+   - `Overshoot`: reserves exceed supply.
+
+`isFullyBacked()` returns `true` for both `Backed` and `Overshoot`.
+
+## Deployment Inputs
+
+- `stablecoin`: ERC-20 stablecoin address. The contract reads `totalSupply()`
+  and `decimals()`.
+- `reserveFeed`: Chainlink Proof of Reserves feed address.
+- `maxFeedAge`: maximum feed age in seconds. Set to `0` to disable staleness
+  checks, though production deployments should prefer an explicit bound.
+
+## Operational Use
+
+Use `reserveStatus()` or `isFullyBacked()` for read-only dashboards and
+monitoring. Use `checkReserves()` when an emitted audit trail is useful:
+
+```solidity
+event ReserveCheckPerformed(uint256 supply, uint256 reserves, bool backed);
+```
+
+The contract reverts on negative feed answers, incomplete rounds, stale data,
+or zero deployment addresses.

--- a/forge-test/ChainlinkReserveProof.t.sol
+++ b/forge-test/ChainlinkReserveProof.t.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/ChainlinkReserveProof.sol";
+import "../contracts/Stablecoin.sol";
+import "../contracts/mocks/ChainlinkPoRMock.sol";
+
+contract ChainlinkReserveProofTest is Test {
+    Stablecoin public stablecoin;
+    ChainlinkPoRMock public reserveFeed;
+    ChainlinkReserveProof public reserveProof;
+
+    address public admin = address(1);
+    address public holder = address(2);
+
+    event ReserveCheckPerformed(uint256 supply, uint256 reserves, bool backed);
+
+    function setUp() public {
+        vm.startPrank(admin);
+        stablecoin = new Stablecoin("CR8 USD", "CR8USD", admin);
+        reserveFeed = new ChainlinkPoRMock(1_000_000_000_000); // 10,000 units, 8 decimals
+        reserveProof = new ChainlinkReserveProof(address(stablecoin), address(reserveFeed), 1 days);
+        vm.stopPrank();
+    }
+
+    function test_isFullyBackedWhenReservesEqualSupply() public {
+        vm.prank(admin);
+        stablecoin.mint(holder, 10_000_000_000); // 10,000 units, 6 decimals
+
+        assertTrue(reserveProof.isFullyBacked());
+        assertEq(
+            uint8(reserveProof.reserveStatus()), uint8(ChainlinkReserveProof.ReserveStatus.Backed)
+        );
+    }
+
+    function test_isFullyBackedWhenReservesExceedSupply() public {
+        vm.prank(admin);
+        stablecoin.mint(holder, 9_000_000_000); // 9,000 units, 6 decimals
+
+        assertTrue(reserveProof.isFullyBacked());
+        assertEq(
+            uint8(reserveProof.reserveStatus()),
+            uint8(ChainlinkReserveProof.ReserveStatus.Overshoot)
+        );
+    }
+
+    function test_isNotFullyBackedWhenSupplyExceedsReserves() public {
+        vm.prank(admin);
+        stablecoin.mint(holder, 12_000_000_000); // 12,000 units, 6 decimals
+
+        assertFalse(reserveProof.isFullyBacked());
+        assertEq(
+            uint8(reserveProof.reserveStatus()),
+            uint8(ChainlinkReserveProof.ReserveStatus.Underbacked)
+        );
+    }
+
+    function test_latestReservesScalesFeedDecimalsToStablecoinDecimals() public view {
+        (uint256 reserves, uint256 updatedAt) = reserveProof.latestReserves();
+
+        assertEq(reserves, 10_000_000_000);
+        assertGt(updatedAt, 0);
+    }
+
+    function test_checkReservesEmitsSupplyReserveAndBackedFlag() public {
+        vm.prank(admin);
+        stablecoin.mint(holder, 10_000_000_000);
+
+        vm.expectEmit(false, false, false, true);
+        emit ReserveCheckPerformed(10_000_000_000, 10_000_000_000, true);
+
+        (ChainlinkReserveProof.ReserveStatus status, bool backed) = reserveProof.checkReserves();
+        assertEq(uint8(status), uint8(ChainlinkReserveProof.ReserveStatus.Backed));
+        assertTrue(backed);
+    }
+
+    function test_revertsWhenReserveFeedIsStale() public {
+        reserveFeed.setAnswerWithTimestamp(1_000_000_000_000, 1);
+        vm.warp(2 days + 1);
+
+        vm.expectRevert(abi.encodeWithSelector(ChainlinkReserveProof.StaleReserveFeed.selector, 1));
+        reserveProof.isFullyBacked();
+    }
+
+    function test_revertsWhenReserveFeedAnswerIsNegative() public {
+        reserveFeed.setAnswer(-1);
+
+        vm.expectRevert(ChainlinkReserveProof.InvalidReserveAnswer.selector);
+        reserveProof.isFullyBacked();
+    }
+
+    function test_revertsWhenConstructedWithZeroStablecoin() public {
+        vm.expectRevert(ChainlinkReserveProof.InvalidStablecoin.selector);
+        new ChainlinkReserveProof(address(0), address(reserveFeed), 1 days);
+    }
+
+    function test_revertsWhenConstructedWithZeroReserveFeed() public {
+        vm.expectRevert(ChainlinkReserveProof.InvalidReserveFeed.selector);
+        new ChainlinkReserveProof(address(stablecoin), address(0), 1 days);
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,8 @@
 [profile.default]
 src = "contracts"
+test = "forge-test"
 out = "forge-out"
-libs = ["node_modules"]
+libs = ["node_modules", "lib"]
 solc = "0.8.24"
 optimizer = true
 optimizer-runs = 200

--- a/web/index.html
+++ b/web/index.html
@@ -65,6 +65,8 @@
   .tag { display: inline-block; font-size: 10px; padding: 2px 7px; border-radius: 4px; font-family: var(--mono); }
   .tag.on { background: rgba(52,211,153,0.15); color: var(--accent); }
   .tag.off { background: rgba(138,147,163,0.12); color: var(--muted); }
+  .tag.warn { background: rgba(251,191,36,0.15); color: var(--warn); }
+  .tag.hot { background: rgba(248,113,113,0.15); color: var(--hot); }
   .geo-card { background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
   .geo-card h4 { margin: 0 0 4px 0; font-size: 14px; }
   .geo-card .sub { color: var(--muted); font-size: 12px; margin-bottom: 10px; }
@@ -156,6 +158,28 @@
       <div class="donut-container" style="margin-top:16px">
         <svg id="donut" width="160" height="160" viewBox="0 0 160 160"></svg>
         <div class="donut-legend" id="donutLegend"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ===== RESERVE PROOF ===== -->
+  <div class="card" style="margin-bottom:16px">
+    <h2>Reserve Proof</h2>
+    <div class="grid-2" style="margin-bottom:10px">
+      <div>
+        <div class="field">
+          <label>Stablecoin totalSupply()</label>
+          <input type="number" id="proofSupply" value="5000000" min="0" step="100000" oninput="drawReserveProof()" />
+        </div>
+        <div class="field">
+          <label>Chainlink PoR reserves</label>
+          <input type="number" id="proofReserves" value="5250000" min="0" step="100000" oninput="drawReserveProof()" />
+        </div>
+      </div>
+      <div>
+        <div class="result-row"><span class="rl">On-chain status</span><span class="rv"><span class="tag on" id="proofStatus">--</span></span></div>
+        <div class="result-row"><span class="rl">Reserve coverage</span><span class="rv" id="proofCoverage">--</span></div>
+        <div class="result-row"><span class="rl">ReserveCheckPerformed</span><span class="rv" id="proofEvent">--</span></div>
       </div>
     </div>
   </div>
@@ -281,6 +305,27 @@ function drawReserve() {
   leg.innerHTML = slices.map(s =>
     `<div><span class="swatch" style="background:${s.color}"></span>${s.label}: <span style="font-family:var(--mono);color:var(--fg)">${fmtUsd(s.value)}</span></div>`
   ).join('');
+}
+
+/* ====== Reserve Proof ====== */
+function drawReserveProof() {
+  const supply = parseFloat(document.getElementById('proofSupply').value) || 0;
+  const reserves = parseFloat(document.getElementById('proofReserves').value) || 0;
+  const statusEl = document.getElementById('proofStatus');
+  const coverageEl = document.getElementById('proofCoverage');
+  const eventEl = document.getElementById('proofEvent');
+
+  let status = 'Backed';
+  let tag = 'on';
+  if (reserves < supply) { status = 'Underbacked'; tag = 'hot'; }
+  else if (reserves > supply) { status = 'Overshoot'; tag = 'warn'; }
+
+  const coverage = supply === 0 ? Infinity : (reserves / supply) * 100;
+  statusEl.textContent = status;
+  statusEl.className = 'tag ' + tag;
+  coverageEl.textContent = supply === 0 ? 'unbounded' : coverage.toFixed(2) + '%';
+  coverageEl.className = 'rv ' + (reserves < supply ? 'hot' : '');
+  eventEl.textContent = `${fmtUsd(supply)} / ${fmtUsd(reserves)} / ${reserves >= supply}`;
 }
 
 /* ====== Burn Toll Impact Chart ====== */
@@ -410,6 +455,7 @@ function renderGeo() {
 /* ====== Init ====== */
 calc();
 drawReserve();
+drawReserveProof();
 drawBurnChart();
 renderCompliance();
 renderGeo();


### PR DESCRIPTION
## Summary
- add `ChainlinkReserveProof` to compare stablecoin `totalSupply()` with a Chainlink Proof of Reserves feed
- expose `isFullyBacked()`, `reserveStatus()`, and `checkReserves()` with `ReserveCheckPerformed` emissions
- wire Foundry to the existing `forge-test/` suite by adding `forge-std`, add reserve proof tests, docs, and a dashboard panel

Fixes #15.

## Validation
- `forge fmt --check contracts/ChainlinkReserveProof.sol forge-test/ChainlinkReserveProof.t.sol`
- `forge test --match-contract ChainlinkReserveProofTest -vv`
- `forge test -vv`
- `npx hardhat test`
- `git diff --check`