### PR TITLE
feat: add Brazil compliance module

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,21 @@ config/geographies/
 | `Stablecoin.sol` | Core ERC-20 with mint/burn, pause, blacklist, permit |
 | `ReserveManager.sol` | Multi-asset reserve tracking and proof of reserves |
 | `ComplianceModule.sol` | KYC, geography restrictions, transaction limits |
+| `compliance/BrazilCompliance.sol` | Brazil extension with hashed CPF validation and PIX settlement hooks |
 | `Minter.sol` | Gateway — compliance + reserve checks before mint/redeem |
 | `DepegGuard.sol` | Depeg-defence watchdog — Normal/Caution/Hard state machine, pauses mints + stablecoin on threshold breaches. Spec: [`docs/depeg-guard.md`](docs/depeg-guard.md) |
 | `ChainlinkPoRAdapter.sol` | Adapter for Chainlink Proof of Reserves feeds |
+
+### Brazil Compliance
+
+`BrazilCompliance` extends the base compliance module for BR issuers:
+
+- stores only off-chain hashed CPF values (`bytes32`), never plaintext tax IDs
+- enforces approved CPF status for accounts in the `BR` geography
+- preserves sanctions, geography allow/deny, max transaction, and daily limit checks
+- emits `PIXSettled(address indexed account, bytes32 indexed pixKey, uint256 amount)` for PIX settlement hooks
+
+Use `setBrazilKYC(account, cpfHash, kycStatus, cpfStatus)` to bind a normalized off-chain CPF hash to an account and `configureBrazil(...)` to tune the BR geography gate.
 
 ## Contributing
 

--- a/contracts/ComplianceModule.sol
+++ b/contracts/ComplianceModule.sol
@@ -9,18 +9,23 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  * @dev Part of kcolbchain/stablecoin-toolkit
  */
 contract ComplianceModule is Ownable {
-    enum KYCStatus { None, Pending, Approved, Rejected }
+    enum KYCStatus {
+        None,
+        Pending,
+        Approved,
+        Rejected
+    }
 
     struct AddressInfo {
         KYCStatus kycStatus;
-        bytes2 geography;        // ISO 3166-1 alpha-2 (e.g. "IN", "US")
+        bytes2 geography; // ISO 3166-1 alpha-2 (e.g. "IN", "US")
         bool sanctioned;
     }
 
     struct GeoConfig {
         bool allowed;
-        uint256 maxTxAmount;     // max per transaction (6 decimals)
-        uint256 dailyLimit;      // max per day (6 decimals)
+        uint256 maxTxAmount; // max per transaction (6 decimals)
+        uint256 dailyLimit; // max per day (6 decimals)
     }
 
     mapping(address => AddressInfo) public addressInfo;
@@ -51,7 +56,10 @@ contract ComplianceModule is Ownable {
         emit GeographySet(account, geo);
     }
 
-    function configureGeography(bytes2 geo, bool allowed, uint256 maxTx, uint256 dailyLimit) external onlyOwner {
+    function configureGeography(bytes2 geo, bool allowed, uint256 maxTx, uint256 dailyLimit)
+        external
+        onlyOwner
+    {
         geoConfigs[geo] = GeoConfig(allowed, maxTx, dailyLimit);
         emit GeoConfigUpdated(geo, allowed, maxTx, dailyLimit);
     }
@@ -66,7 +74,7 @@ contract ComplianceModule is Ownable {
         emit Unsanctioned(account);
     }
 
-    function checkCompliance(address account, uint256 amount) external view {
+    function checkCompliance(address account, uint256 amount) public view virtual {
         AddressInfo storage info = addressInfo[account];
 
         if (info.sanctioned) revert AddressSanctioned(account);

--- a/contracts/compliance/BrazilCompliance.sol
+++ b/contracts/compliance/BrazilCompliance.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "../ComplianceModule.sol";
+
+/**
+ * @title BrazilCompliance
+ * @notice Brazil-specific compliance extension with hashed CPF validation and PIX settlement hooks.
+ * @dev CPF values must be normalized and hashed off-chain. This contract never stores plaintext CPF.
+ */
+contract BrazilCompliance is ComplianceModule {
+    bytes2 public constant BR = bytes2("BR");
+
+    enum CPFStatus {
+        None,
+        Approved,
+        Rejected
+    }
+
+    mapping(address => bytes32) public cpfHashOf;
+    mapping(bytes32 => CPFStatus) public cpfStatus;
+
+    event CPFUpdated(address indexed account, bytes32 indexed cpfHash, CPFStatus status);
+    event PIXSettled(address indexed account, bytes32 indexed pixKey, uint256 amount);
+
+    error InvalidCPFHash();
+    error CPFNotApproved(address account, bytes32 cpfHash);
+
+    constructor(uint256 maxTxAmount, uint256 dailyLimit) {
+        geoConfigs[BR] =
+            GeoConfig({allowed: true, maxTxAmount: maxTxAmount, dailyLimit: dailyLimit});
+        emit GeoConfigUpdated(BR, true, maxTxAmount, dailyLimit);
+    }
+
+    /**
+     * @notice Sets KYC and CPF status for a Brazil account in a single owner-gated operation.
+     * @param account Wallet controlled by the CPF holder.
+     * @param cpfHash Hash of the normalized CPF, computed off-chain.
+     * @param kycStatus Base KYC status used by ComplianceModule.
+     * @param status Brazil-specific CPF approval status.
+     */
+    function setBrazilKYC(address account, bytes32 cpfHash, KYCStatus kycStatus, CPFStatus status)
+        external
+        onlyOwner
+    {
+        if (cpfHash == bytes32(0)) revert InvalidCPFHash();
+
+        addressInfo[account].kycStatus = kycStatus;
+        addressInfo[account].geography = BR;
+        cpfHashOf[account] = cpfHash;
+        cpfStatus[cpfHash] = status;
+
+        emit KYCUpdated(account, kycStatus);
+        emit GeographySet(account, BR);
+        emit CPFUpdated(account, cpfHash, status);
+    }
+
+    function setCPFStatus(bytes32 cpfHash, CPFStatus status) external onlyOwner {
+        if (cpfHash == bytes32(0)) revert InvalidCPFHash();
+        cpfStatus[cpfHash] = status;
+        emit CPFUpdated(address(0), cpfHash, status);
+    }
+
+    function configureBrazil(bool allowed, uint256 maxTxAmount, uint256 dailyLimit)
+        external
+        onlyOwner
+    {
+        geoConfigs[BR] =
+            GeoConfig({allowed: allowed, maxTxAmount: maxTxAmount, dailyLimit: dailyLimit});
+        emit GeoConfigUpdated(BR, allowed, maxTxAmount, dailyLimit);
+    }
+
+    function checkCompliance(address account, uint256 amount) public view override {
+        super.checkCompliance(account, amount);
+
+        if (addressInfo[account].geography == BR) {
+            bytes32 cpfHash = cpfHashOf[account];
+            if (cpfHash == bytes32(0) || cpfStatus[cpfHash] != CPFStatus.Approved) {
+                revert CPFNotApproved(account, cpfHash);
+            }
+        }
+    }
+
+    /**
+     * @notice Emits a PIX settlement hook after confirming Brazil compliance.
+     * @param account Account whose redemption/settlement is being paid.
+     * @param pixKey Hash or off-chain identifier for the PIX key.
+     * @param amount Settlement amount in stablecoin base units.
+     */
+    function settlePIX(address account, bytes32 pixKey, uint256 amount) external onlyOwner {
+        checkCompliance(account, amount);
+        emit PIXSettled(account, pixKey, amount);
+    }
+}

--- a/forge-test/BrazilCompliance.t.sol
+++ b/forge-test/BrazilCompliance.t.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/ComplianceModule.sol";
+import "../contracts/compliance/BrazilCompliance.sol";
+
+contract BrazilComplianceTest is Test {
+    BrazilCompliance public br;
+    address public admin = address(1);
+    address public user = address(2);
+    address public other = address(3);
+
+    bytes32 public constant CPF_HASH = keccak256("12345678909");
+    bytes32 public constant REJECTED_CPF_HASH = keccak256("98765432100");
+    bytes32 public constant PIX_KEY = keccak256("user@example.com");
+
+    function setUp() public {
+        vm.prank(admin);
+        br = new BrazilCompliance(1_000_000, 5_000_000);
+
+        vm.prank(admin);
+        br.setBrazilKYC(
+            user, CPF_HASH, ComplianceModule.KYCStatus.Approved, BrazilCompliance.CPFStatus.Approved
+        );
+    }
+
+    function test_approvedCPFPassesCompliance() public view {
+        br.checkCompliance(user, 500_000);
+        assertEq(br.cpfHashOf(user), CPF_HASH);
+        assertEq(uint256(br.cpfStatus(CPF_HASH)), uint256(BrazilCompliance.CPFStatus.Approved));
+    }
+
+    function test_rejectedCPFReverts() public {
+        vm.prank(admin);
+        br.setBrazilKYC(
+            other,
+            REJECTED_CPF_HASH,
+            ComplianceModule.KYCStatus.Approved,
+            BrazilCompliance.CPFStatus.Rejected
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BrazilCompliance.CPFNotApproved.selector, other, REJECTED_CPF_HASH
+            )
+        );
+        br.checkCompliance(other, 100);
+    }
+
+    function test_missingCPFRevertsForBrazilAccount() public {
+        vm.startPrank(admin);
+        br.setKYC(other, ComplianceModule.KYCStatus.Approved);
+        br.setGeography(other, br.BR());
+        vm.stopPrank();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(BrazilCompliance.CPFNotApproved.selector, other, bytes32(0))
+        );
+        br.checkCompliance(other, 100);
+    }
+
+    function test_sanctionedListOverridesCPFApproval() public {
+        vm.prank(admin);
+        br.sanction(user);
+
+        vm.expectRevert(abi.encodeWithSelector(ComplianceModule.AddressSanctioned.selector, user));
+        br.checkCompliance(user, 100);
+    }
+
+    function test_geographyGateStillAppliesToBrazil() public {
+        vm.prank(admin);
+        br.configureBrazil(false, 1_000_000, 5_000_000);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ComplianceModule.GeographyRestricted.selector, br.BR())
+        );
+        br.checkCompliance(user, 100);
+    }
+
+    function test_txLimitStillAppliesToBrazil() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(ComplianceModule.ExceedsTxLimit.selector, 2_000_000, 1_000_000)
+        );
+        br.checkCompliance(user, 2_000_000);
+    }
+
+    function test_pixSettlementEmitsIndexedHook() public {
+        vm.expectEmit(true, true, false, true);
+        emit BrazilCompliance.PIXSettled(user, PIX_KEY, 250_000);
+
+        vm.prank(admin);
+        br.settlePIX(user, PIX_KEY, 250_000);
+    }
+
+    function test_invalidCPFHashRejected() public {
+        vm.prank(admin);
+        vm.expectRevert(BrazilCompliance.InvalidCPFHash.selector);
+        br.setBrazilKYC(
+            other,
+            bytes32(0),
+            ComplianceModule.KYCStatus.Approved,
+            BrazilCompliance.CPFStatus.Approved
+        );
+    }
+
+    function test_brazilComplianceGasOverheadIsBounded() public {
+        ComplianceModule base = new ComplianceModule();
+        address baseUser = address(10);
+        base.setKYC(baseUser, ComplianceModule.KYCStatus.Approved);
+        base.setGeography(baseUser, br.BR());
+        base.configureGeography(br.BR(), true, 1_000_000, 5_000_000);
+
+        uint256 beforeBase = gasleft();
+        base.checkCompliance(baseUser, 100);
+        uint256 baseGas = beforeBase - gasleft();
+
+        uint256 beforeBrazil = gasleft();
+        br.checkCompliance(user, 100);
+        uint256 brazilGas = beforeBrazil - gasleft();
+
+        emit log_named_uint("base_check_gas", baseGas);
+        emit log_named_uint("brazil_check_gas", brazilGas);
+        emit log_named_uint("brazil_overhead_gas", brazilGas - baseGas);
+
+        assertLt(brazilGas - baseGas, 15_000);
+    }
+}

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,6 @@
 [profile.default]
 src = "contracts"
+test = "forge-test"
 out = "forge-out"
 libs = ["node_modules"]
 solc = "0.8.24"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
+    "forge-std": "github:foundry-rs/forge-std#v1.9.6",
     "hardhat": "^2.19.0"
   },
   "license": "MIT"

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,1 +1,2 @@
 @openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
+forge-std/=node_modules/forge-std/src/


### PR DESCRIPTION
## Summary
- add `BrazilCompliance`, a BR-specific `ComplianceModule` extension with off-chain hashed CPF binding and approval status
- preserve the existing sanctions, KYC, geography allow/deny, tx limit, and daily-limit checks by overriding `checkCompliance`
- add an indexed `PIXSettled(address, bytes32, uint256)` hook after compliance validation
- add Foundry coverage for approved/rejected/missing CPF, sanctions override, BR geography gate, tx limit interaction, PIX emission, and invalid CPF hashes
- wire Foundry to the existing `forge-test/` directory and add the `forge-std` remapping/dependency needed to run those tests

Gas note: the Foundry gas comparison test logs `base_check_gas: 4469`, `brazil_check_gas: 19437`, and `brazil_overhead_gas: 14968` for the happy-path compliance check.

Addresses #28.

## Validation
- `forge fmt --check contracts/ComplianceModule.sol contracts/compliance/BrazilCompliance.sol forge-test/BrazilCompliance.t.sol`
- `forge test --match-contract BrazilComplianceTest -vv`
- `forge test` => 68 passing
- `npx hardhat compile`
- `npm test` => 47 passing
- `git diff --check`
