### PR TITLE
feat: add burn toll extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Built on learnings from real stablecoin deployments. Production-grade Solidity c
 - **Reserve manager** — multi-asset reserve tracking, on-chain proof of reserves, ratio enforcement
 - **Compliance module** — KYC status per address, geography-based transfer restrictions, transaction limits
 - **Minting gateway** — compliance-checked minting, redemption queue, fee management
+- **Burn toll extension** — optional mint/redeem hook that routes configurable toll revenue to a floor-pool adapter for governance-token buy-and-burn execution
 - **Depeg defence** — `DepegGuard` state machine monitors the collateral price feed and pauses mints / stablecoin on threshold breaches; see [`docs/depeg-guard.md`](docs/depeg-guard.md)
 - **Multi-geography** — configurable per jurisdiction (see `config/geographies/`)
 - **Role-based access** — MINTER, PAUSER, BLACKLISTER roles via OpenZeppelin AccessControl
@@ -72,6 +73,7 @@ config/geographies/
 | `ReserveManager.sol` | Multi-asset reserve tracking and proof of reserves |
 | `ComplianceModule.sol` | KYC, geography restrictions, transaction limits |
 | `Minter.sol` | Gateway — compliance + reserve checks before mint/redeem |
+| `extensions/BurnToll.sol` | Optional 0.5% default mint/redeem toll routed to a floor-pool buy-and-burn adapter. Spec: [`docs/burn-toll.md`](docs/burn-toll.md) |
 | `DepegGuard.sol` | Depeg-defence watchdog — Normal/Caution/Hard state machine, pauses mints + stablecoin on threshold breaches. Spec: [`docs/depeg-guard.md`](docs/depeg-guard.md) |
 | `ChainlinkPoRAdapter.sol` | Adapter for Chainlink Proof of Reserves feeds |
 

--- a/contracts/Minter.sol
+++ b/contracts/Minter.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "./Stablecoin.sol";
 import "./ReserveManager.sol";
 import "./ComplianceModule.sol";
+import "./extensions/BurnToll.sol";
 
 /**
  * @title Minter
@@ -19,6 +20,7 @@ contract Minter is Ownable {
     uint256 public mintFeeBps;    // e.g. 10 = 0.1%
     uint256 public redeemFeeBps;
     address public feeCollector;
+    BurnToll public burnToll;
 
     mapping(address => bool) public authorizedMinters;
 
@@ -37,10 +39,12 @@ contract Minter is Ownable {
     event RedemptionSettled(uint256 indexed id);
     event MinterAuthorized(address indexed minter);
     event MinterRevoked(address indexed minter);
+    event BurnTollSet(address indexed burnToll);
 
     error NotAuthorizedMinter();
     error ReserveCheckFailed();
     error AlreadySettled();
+    error AmountTooSmallForFeesAndToll();
 
     modifier onlyAuthorizedMinter() {
         if (!authorizedMinters[msg.sender] && msg.sender != owner()) {
@@ -86,12 +90,18 @@ contract Minter is Ownable {
 
         // Calculate fee
         uint256 fee = (amount * mintFeeBps) / 10000;
-        uint256 netAmount = amount - fee;
+        uint256 toll = _previewMintToll(amount);
+        if (fee + toll > amount) revert AmountTooSmallForFeesAndToll();
+        uint256 netAmount = amount - fee - toll;
 
         // Mint
         stablecoin.mint(to, netAmount);
         if (fee > 0) {
             stablecoin.mint(feeCollector, fee);
+        }
+        if (toll > 0) {
+            stablecoin.mint(address(burnToll), toll);
+            burnToll.handleMintToll(address(stablecoin), toll);
         }
 
         // Record daily spend for compliance
@@ -105,9 +115,17 @@ contract Minter is Ownable {
         compliance.checkCompliance(msg.sender, amount);
 
         uint256 fee = (amount * redeemFeeBps) / 10000;
+        uint256 toll = _previewRedeemToll(amount);
+        if (fee + toll > amount) revert AmountTooSmallForFeesAndToll();
+        uint256 burnAmount = amount - toll;
+        uint256 redeemAmount = amount - fee - toll;
 
-        // Burn tokens
-        stablecoin.burnFrom(msg.sender, amount);
+        // Burn tokens and route toll revenue
+        if (toll > 0) {
+            stablecoin.transferFrom(msg.sender, address(burnToll), toll);
+            burnToll.handleRedeemToll(address(stablecoin), toll);
+        }
+        stablecoin.burnFrom(msg.sender, burnAmount);
 
         // Update tracked supply
         reserveManager.updateTrackedSupply(stablecoin.totalSupply());
@@ -115,13 +133,13 @@ contract Minter is Ownable {
         // Queue redemption for settlement
         redemptions.push(Redemption({
             redeemer: msg.sender,
-            amount: amount - fee,
+            amount: redeemAmount,
             fee: fee,
             timestamp: block.timestamp,
             settled: false
         }));
 
-        emit RedemptionQueued(redemptions.length - 1, msg.sender, amount - fee);
+        emit RedemptionQueued(redemptions.length - 1, msg.sender, redeemAmount);
     }
 
     function settleRedemption(uint256 id) external onlyOwner {
@@ -139,7 +157,26 @@ contract Minter is Ownable {
         feeCollector = _feeCollector;
     }
 
+    /**
+     * @notice Sets or disables the optional burn-toll extension.
+     * @param _burnToll BurnToll contract address, or zero address to disable toll collection.
+     */
+    function setBurnToll(address _burnToll) external onlyOwner {
+        burnToll = BurnToll(_burnToll);
+        emit BurnTollSet(_burnToll);
+    }
+
     function getRedemptionCount() external view returns (uint256) {
         return redemptions.length;
+    }
+
+    function _previewMintToll(uint256 amount) internal view returns (uint256) {
+        if (address(burnToll) == address(0)) return 0;
+        return burnToll.previewMintToll(address(stablecoin), amount);
+    }
+
+    function _previewRedeemToll(uint256 amount) internal view returns (uint256) {
+        if (address(burnToll) == address(0)) return 0;
+        return burnToll.previewRedeemToll(address(stablecoin), amount);
     }
 }

--- a/contracts/extensions/BurnToll.sol
+++ b/contracts/extensions/BurnToll.sol
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+interface IBurnTollFloorPool {
+    function depth(address stablecoin, address burnToken) external view returns (uint256);
+    function buyAndBurn(address stablecoin, address burnToken, uint256 amount) external;
+}
+
+/**
+ * @title BurnToll
+ * @notice Optional mint/redeem toll extension that routes stablecoin toll revenue to a floor pool for buy-and-burn execution.
+ * @dev The floor pool is an adapter so deployments can wire an AMM, aggregator, or treasury execution contract without changing the minter.
+ */
+contract BurnToll is Ownable {
+    using SafeERC20 for IERC20;
+
+    uint256 public constant MAX_BPS = 10_000;
+
+    uint256 public mintTollBps = 50;
+    uint256 public redeemTollBps = 50;
+    address public burnTokenAddress;
+    address public floorPoolAddress;
+    uint256 public floorPoolMinDepth;
+    address public minter;
+
+    event BurnTollConfigured(
+        uint256 mintTollBps,
+        uint256 redeemTollBps,
+        address indexed burnTokenAddress,
+        address indexed floorPoolAddress,
+        uint256 floorPoolMinDepth
+    );
+    event MinterSet(address indexed minter);
+    event TollRouted(
+        address indexed stablecoin, address indexed burnToken, uint256 amount, bool isRedeem
+    );
+
+    error TollBpsTooHigh(uint256 tollBps);
+    error NotMinter(address caller);
+    error ZeroAddress();
+
+    modifier onlyMinter() {
+        if (msg.sender != minter) revert NotMinter(msg.sender);
+        _;
+    }
+
+    constructor(address _burnTokenAddress, address _floorPoolAddress, uint256 _floorPoolMinDepth)
+        Ownable(msg.sender)
+    {
+        _configure(50, 50, _burnTokenAddress, _floorPoolAddress, _floorPoolMinDepth);
+    }
+
+    /**
+     * @notice Sets the minter allowed to call toll routing hooks.
+     * @param _minter Minter contract address.
+     */
+    function setMinter(address _minter) external onlyOwner {
+        if (_minter == address(0)) revert ZeroAddress();
+        minter = _minter;
+        emit MinterSet(_minter);
+    }
+
+    /**
+     * @notice Updates toll rates and routing parameters.
+     * @param _mintTollBps Mint toll in basis points.
+     * @param _redeemTollBps Redeem toll in basis points.
+     * @param _burnTokenAddress Token bought and burned by the floor pool.
+     * @param _floorPoolAddress Floor pool adapter receiving stablecoin toll revenue.
+     * @param _floorPoolMinDepth Minimum floor-pool depth required before toll collection.
+     */
+    function configure(
+        uint256 _mintTollBps,
+        uint256 _redeemTollBps,
+        address _burnTokenAddress,
+        address _floorPoolAddress,
+        uint256 _floorPoolMinDepth
+    ) external onlyOwner {
+        _configure(
+            _mintTollBps, _redeemTollBps, _burnTokenAddress, _floorPoolAddress, _floorPoolMinDepth
+        );
+    }
+
+    /**
+     * @notice Calculates the mint toll for an amount, returning zero when the floor pool is not sufficiently deep.
+     * @param stablecoin Stablecoin being tolled.
+     * @param amount Gross mint amount.
+     */
+    function previewMintToll(address stablecoin, uint256 amount) external view returns (uint256) {
+        return _previewToll(stablecoin, amount, mintTollBps);
+    }
+
+    /**
+     * @notice Calculates the redeem toll for an amount, returning zero when the floor pool is not sufficiently deep.
+     * @param stablecoin Stablecoin being tolled.
+     * @param amount Gross redeem amount.
+     */
+    function previewRedeemToll(address stablecoin, uint256 amount) external view returns (uint256) {
+        return _previewToll(stablecoin, amount, redeemTollBps);
+    }
+
+    /**
+     * @notice Routes a mint toll already transferred to this contract.
+     * @param stablecoin Stablecoin toll token.
+     * @param amount Toll amount.
+     */
+    function handleMintToll(address stablecoin, uint256 amount) external onlyMinter {
+        _routeToll(stablecoin, amount, false);
+    }
+
+    /**
+     * @notice Routes a redeem toll already transferred to this contract.
+     * @param stablecoin Stablecoin toll token.
+     * @param amount Toll amount.
+     */
+    function handleRedeemToll(address stablecoin, uint256 amount) external onlyMinter {
+        _routeToll(stablecoin, amount, true);
+    }
+
+    function _configure(
+        uint256 _mintTollBps,
+        uint256 _redeemTollBps,
+        address _burnTokenAddress,
+        address _floorPoolAddress,
+        uint256 _floorPoolMinDepth
+    ) internal {
+        if (_mintTollBps > MAX_BPS) revert TollBpsTooHigh(_mintTollBps);
+        if (_redeemTollBps > MAX_BPS) revert TollBpsTooHigh(_redeemTollBps);
+        if (_burnTokenAddress == address(0) || _floorPoolAddress == address(0)) {
+            revert ZeroAddress();
+        }
+
+        mintTollBps = _mintTollBps;
+        redeemTollBps = _redeemTollBps;
+        burnTokenAddress = _burnTokenAddress;
+        floorPoolAddress = _floorPoolAddress;
+        floorPoolMinDepth = _floorPoolMinDepth;
+
+        emit BurnTollConfigured(
+            _mintTollBps, _redeemTollBps, _burnTokenAddress, _floorPoolAddress, _floorPoolMinDepth
+        );
+    }
+
+    function _previewToll(address stablecoin, uint256 amount, uint256 tollBps)
+        internal
+        view
+        returns (uint256)
+    {
+        if (tollBps == 0 || !_hasEnoughFloorPoolDepth(stablecoin)) {
+            return 0;
+        }
+        return (amount * tollBps) / MAX_BPS;
+    }
+
+    function _hasEnoughFloorPoolDepth(address stablecoin) internal view returns (bool) {
+        return IBurnTollFloorPool(floorPoolAddress).depth(stablecoin, burnTokenAddress)
+            >= floorPoolMinDepth;
+    }
+
+    function _routeToll(address stablecoin, uint256 amount, bool isRedeem) internal {
+        if (amount == 0) {
+            return;
+        }
+
+        IERC20(stablecoin).safeTransfer(floorPoolAddress, amount);
+        IBurnTollFloorPool(floorPoolAddress).buyAndBurn(stablecoin, burnTokenAddress, amount);
+        emit TollRouted(stablecoin, burnTokenAddress, amount, isRedeem);
+    }
+}

--- a/docs/burn-toll.md
+++ b/docs/burn-toll.md
@@ -1,0 +1,25 @@
+# Burn Toll Extension
+
+`BurnToll` is an optional mint and redeem hook for stablecoin deployments that want deflationary pressure on a paired governance token.
+
+## Wiring
+
+1. Deploy the governance burn token or use an existing ERC-20.
+2. Deploy a floor-pool adapter that implements `IBurnTollFloorPool`.
+3. Deploy `BurnToll` with the burn token, floor-pool adapter, and minimum pool depth.
+4. Call `BurnToll.setMinter(minter)`.
+5. Call `Minter.setBurnToll(burnToll)`.
+
+When enabled, `Minter.mint()` mints the toll portion to `BurnToll`, which forwards it to the floor pool and calls `buyAndBurn()`. `Minter.redeem()` transfers the toll portion from the redeemer to `BurnToll`, then routes it the same way. If pool depth is below `floorPoolMinDepth`, the toll is skipped.
+
+## Defaults
+
+- `mintTollBps`: `50` (0.5%)
+- `redeemTollBps`: `50` (0.5%)
+- `floorPoolMinDepth`: deployment-defined, in stablecoin base units
+
+## Rollback
+
+1. Call `Minter.setBurnToll(address(0))` to disable mint and redeem toll collection.
+2. If needed, call `BurnToll.configure(0, 0, burnToken, floorPool, minDepth)` to leave the extension deployed but inert.
+3. Update deployment documentation and front-end quote displays so users no longer see burn-toll estimates.

--- a/forge-test/BurnToll.t.sol
+++ b/forge-test/BurnToll.t.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import "../contracts/Stablecoin.sol";
+import "../contracts/Minter.sol";
+import "../contracts/ReserveManager.sol";
+import "../contracts/ComplianceModule.sol";
+import "../contracts/extensions/BurnToll.sol";
+
+contract BurnTokenMock is ERC20, ERC20Burnable {
+    constructor() ERC20("Burn Token", "BURN") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract FloorPoolMock is IBurnTollFloorPool {
+    uint256 public poolDepth;
+    address public lastStablecoin;
+    address public lastBurnToken;
+    uint256 public lastAmount;
+    uint256 public callCount;
+
+    function setDepth(uint256 depth_) external {
+        poolDepth = depth_;
+    }
+
+    function depth(address, address) external view returns (uint256) {
+        return poolDepth;
+    }
+
+    function buyAndBurn(address stablecoin, address burnToken, uint256 amount) external {
+        lastStablecoin = stablecoin;
+        lastBurnToken = burnToken;
+        lastAmount = amount;
+        callCount++;
+    }
+}
+
+contract BurnTollTest is Test {
+    Stablecoin public coin;
+    Minter public minter;
+    ReserveManager public rm;
+    ComplianceModule public cm;
+    BurnTokenMock public burnToken;
+    FloorPoolMock public floorPool;
+    BurnToll public burnToll;
+
+    address public admin = address(1);
+    address public user1 = address(2);
+    address public feeCollector = address(3);
+    bytes2 constant US = bytes2("US");
+
+    function setUp() public {
+        vm.startPrank(admin);
+
+        coin = new Stablecoin("Test Stablecoin", "TSTBL", admin);
+        rm = new ReserveManager(10_000);
+        cm = new ComplianceModule();
+        burnToken = new BurnTokenMock();
+        floorPool = new FloorPoolMock();
+
+        rm.addReserveAsset(keccak256("USD_BANK"), "USD Bank", 2_000_000_000_000);
+        cm.setKYC(user1, ComplianceModule.KYCStatus.Approved);
+        cm.setGeography(user1, US);
+        cm.configureGeography(US, true, 2_000_000_000_000, 2_000_000_000_000);
+
+        minter = new Minter(address(coin), address(rm), address(cm), 10, 10, feeCollector);
+
+        burnToll = new BurnToll(address(burnToken), address(floorPool), 100_000_000);
+        burnToll.setMinter(address(minter));
+
+        coin.grantRole(coin.MINTER_ROLE(), address(minter));
+        rm.transferOwnership(address(minter));
+        cm.transferOwnership(address(minter));
+
+        minter.authorizeMinter(admin);
+        minter.setBurnToll(address(burnToll));
+        floorPool.setDepth(1_000_000_000);
+
+        vm.stopPrank();
+    }
+
+    function test_mintRoutesTollWhenPoolIsDeepEnough() public {
+        uint256 amount = 1_000_000_000;
+
+        vm.prank(admin);
+        minter.mint(user1, amount);
+
+        assertEq(coin.balanceOf(user1), 994_000_000);
+        assertEq(coin.balanceOf(feeCollector), 1_000_000);
+        assertEq(coin.balanceOf(address(floorPool)), 5_000_000);
+        assertEq(floorPool.lastStablecoin(), address(coin));
+        assertEq(floorPool.lastBurnToken(), address(burnToken));
+        assertEq(floorPool.lastAmount(), 5_000_000);
+        assertEq(floorPool.callCount(), 1);
+    }
+
+    function test_mintSkipsTollWhenPoolDepthIsLow() public {
+        floorPool.setDepth(99_999_999);
+
+        vm.prank(admin);
+        minter.mint(user1, 1_000_000_000);
+
+        assertEq(coin.balanceOf(user1), 999_000_000);
+        assertEq(coin.balanceOf(feeCollector), 1_000_000);
+        assertEq(coin.balanceOf(address(floorPool)), 0);
+        assertEq(floorPool.callCount(), 0);
+    }
+
+    function test_redeemRoutesTollAndReducesQueuedPayout() public {
+        vm.prank(admin);
+        minter.mint(user1, 1_000_000_000);
+
+        vm.prank(user1);
+        coin.approve(address(minter), type(uint256).max);
+
+        vm.prank(user1);
+        minter.redeem(100_000_000);
+
+        (, uint256 amount, uint256 fee,,) = minter.redemptions(0);
+        assertEq(amount, 99_400_000);
+        assertEq(fee, 100_000);
+        assertEq(coin.balanceOf(address(floorPool)), 5_500_000);
+        assertEq(floorPool.lastAmount(), 500_000);
+        assertEq(floorPool.callCount(), 2);
+    }
+
+    function test_governanceCanReconfigureTolls() public {
+        vm.prank(admin);
+        burnToll.configure(100, 25, address(burnToken), address(floorPool), 100_000_000);
+
+        assertEq(burnToll.previewMintToll(address(coin), 1_000_000_000), 10_000_000);
+        assertEq(burnToll.previewRedeemToll(address(coin), 1_000_000_000), 2_500_000);
+    }
+
+    function test_zeroTollConfigSkipsRouting() public {
+        vm.prank(admin);
+        burnToll.configure(0, 0, address(burnToken), address(floorPool), 100_000_000);
+
+        vm.prank(admin);
+        minter.mint(user1, 1_000_000_000);
+
+        assertEq(coin.balanceOf(user1), 999_000_000);
+        assertEq(coin.balanceOf(address(floorPool)), 0);
+        assertEq(floorPool.callCount(), 0);
+    }
+
+    function test_mintTollMathAcrossAmountsAndDepths() public {
+        uint256[3] memory amounts =
+            [uint256(1_000_000_000), uint256(100_000_000_000), uint256(1_000_000_000_000)];
+        uint256[3] memory depths =
+            [uint256(10_000_000_000), uint256(100_000_000_000), uint256(1_000_000_000_000)];
+
+        for (uint256 i = 0; i < depths.length; i++) {
+            floorPool.setDepth(depths[i]);
+            for (uint256 j = 0; j < amounts.length; j++) {
+                assertEq(
+                    burnToll.previewMintToll(address(coin), amounts[j]), (amounts[j] * 50) / 10_000
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements #18.

## Summary
- Adds `contracts/extensions/BurnToll.sol`, an optional mint/redeem toll hook with 0.5% default tolls, configurable burn token, floor-pool adapter, and minimum-depth gating.
- Wires `Minter` to route mint tolls and redeem tolls when the extension is enabled, while preserving current behavior when disabled.
- Adds Foundry coverage for toll math, low-liquidity skip behavior, governance reconfiguration, zero-toll config, and redeem payout accounting.
- Documents deployment wiring and rollback steps in `docs/burn-toll.md`.

## Validation
- `FOUNDRY_LIBS=["node_modules","/tmp/codex-forge-libs"] FOUNDRY_TEST=forge-test forge test -vv`
- `npx hardhat test`
- `forge fmt --check contracts/extensions/BurnToll.sol forge-test/BurnToll.t.sol`
- `git diff --check`