### PR TITLE
Add optional burn-toll extension for mint and redeem flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Built on learnings from real stablecoin deployments. Production-grade Solidity c
 - **Reserve manager** — multi-asset reserve tracking, on-chain proof of reserves, ratio enforcement
 - **Compliance module** — KYC status per address, geography-based transfer restrictions, transaction limits
 - **Minting gateway** — compliance-checked minting, redemption queue, fee management
+- **Burn-toll extension** — optional 0.5% mint/redeem toll routed through a floor pool to buy + burn a paired governance token
 - **Depeg defence** — `DepegGuard` state machine monitors the collateral price feed and pauses mints / stablecoin on threshold breaches; see [`docs/depeg-guard.md`](docs/depeg-guard.md)
 - **Multi-geography** — configurable per jurisdiction (see `config/geographies/`)
 - **Role-based access** — MINTER, PAUSER, BLACKLISTER roles via OpenZeppelin AccessControl
@@ -72,6 +73,7 @@ config/geographies/
 | `ReserveManager.sol` | Multi-asset reserve tracking and proof of reserves |
 | `ComplianceModule.sol` | KYC, geography restrictions, transaction limits |
 | `Minter.sol` | Gateway — compliance + reserve checks before mint/redeem |
+| `extensions/BurnToll.sol` | Optional mint/redeem toll module with low-liquidity skip checks. Wiring guide: [`docs/burn-toll.md`](docs/burn-toll.md) |
 | `DepegGuard.sol` | Depeg-defence watchdog — Normal/Caution/Hard state machine, pauses mints + stablecoin on threshold breaches. Spec: [`docs/depeg-guard.md`](docs/depeg-guard.md) |
 | `ChainlinkPoRAdapter.sol` | Adapter for Chainlink Proof of Reserves feeds |
 

--- a/contracts/Minter.sol
+++ b/contracts/Minter.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "./Stablecoin.sol";
 import "./ReserveManager.sol";
 import "./ComplianceModule.sol";
+import "./extensions/BurnToll.sol";
 
 /**
  * @title Minter
@@ -15,6 +16,7 @@ contract Minter is Ownable {
     Stablecoin public stablecoin;
     ReserveManager public reserveManager;
     ComplianceModule public compliance;
+    BurnToll public burnToll;
 
     uint256 public mintFeeBps;    // e.g. 10 = 0.1%
     uint256 public redeemFeeBps;
@@ -37,6 +39,8 @@ contract Minter is Ownable {
     event RedemptionSettled(uint256 indexed id);
     event MinterAuthorized(address indexed minter);
     event MinterRevoked(address indexed minter);
+    event BurnTollSet(address indexed burnToll);
+    event BurnTollApplied(bool indexed mintToll, uint256 amount);
 
     error NotAuthorizedMinter();
     error ReserveCheckFailed();
@@ -75,6 +79,15 @@ contract Minter is Ownable {
         emit MinterRevoked(minter);
     }
 
+    /**
+     * @notice Sets the optional burn-toll module used by mint and redeem.
+     * @param _burnToll BurnToll module address, or zero address to disable it.
+     */
+    function setBurnToll(address _burnToll) external onlyOwner {
+        burnToll = BurnToll(_burnToll);
+        emit BurnTollSet(_burnToll);
+    }
+
     function mint(address to, uint256 amount) external onlyAuthorizedMinter {
         // Check compliance
         compliance.checkCompliance(to, amount);
@@ -86,12 +99,18 @@ contract Minter is Ownable {
 
         // Calculate fee
         uint256 fee = (amount * mintFeeBps) / 10000;
-        uint256 netAmount = amount - fee;
+        uint256 toll = _previewMintToll(amount);
+        uint256 netAmount = amount - fee - toll;
 
         // Mint
         stablecoin.mint(to, netAmount);
         if (fee > 0) {
             stablecoin.mint(feeCollector, fee);
+        }
+        if (toll > 0) {
+            stablecoin.mint(address(burnToll), toll);
+            burnToll.routeMintToll(toll);
+            emit BurnTollApplied(true, toll);
         }
 
         // Record daily spend for compliance
@@ -105,9 +124,16 @@ contract Minter is Ownable {
         compliance.checkCompliance(msg.sender, amount);
 
         uint256 fee = (amount * redeemFeeBps) / 10000;
+        uint256 toll = _previewRedeemToll(amount);
+        uint256 netRedemption = amount - fee - toll;
 
         // Burn tokens
         stablecoin.burnFrom(msg.sender, amount);
+        if (toll > 0) {
+            stablecoin.mint(address(burnToll), toll);
+            burnToll.routeRedeemToll(toll);
+            emit BurnTollApplied(false, toll);
+        }
 
         // Update tracked supply
         reserveManager.updateTrackedSupply(stablecoin.totalSupply());
@@ -115,13 +141,13 @@ contract Minter is Ownable {
         // Queue redemption for settlement
         redemptions.push(Redemption({
             redeemer: msg.sender,
-            amount: amount - fee,
+            amount: netRedemption,
             fee: fee,
             timestamp: block.timestamp,
             settled: false
         }));
 
-        emit RedemptionQueued(redemptions.length - 1, msg.sender, amount - fee);
+        emit RedemptionQueued(redemptions.length - 1, msg.sender, netRedemption);
     }
 
     function settleRedemption(uint256 id) external onlyOwner {
@@ -141,5 +167,17 @@ contract Minter is Ownable {
 
     function getRedemptionCount() external view returns (uint256) {
         return redemptions.length;
+    }
+
+    function _previewMintToll(uint256 amount) internal view returns (uint256) {
+        if (address(burnToll) == address(0)) return 0;
+        (uint256 tollAmount, , ) = burnToll.previewMintToll(amount);
+        return tollAmount;
+    }
+
+    function _previewRedeemToll(uint256 amount) internal view returns (uint256) {
+        if (address(burnToll) == address(0)) return 0;
+        (uint256 tollAmount, , ) = burnToll.previewRedeemToll(amount);
+        return tollAmount;
     }
 }

--- a/contracts/extensions/BurnToll.sol
+++ b/contracts/extensions/BurnToll.sol
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "../Stablecoin.sol";
+import "../interfaces/IBurnTollFloorPool.sol";
+
+/**
+ * @title BurnToll
+ * @notice Optional mint/redeem toll module that routes stablecoin tolls into a
+ *         floor pool which buys and burns a paired governance token.
+ * @dev Configuration is controlled by the existing Stablecoin admin role.
+ */
+contract BurnToll {
+    using SafeERC20 for IERC20;
+
+    uint256 public constant BPS_DENOMINATOR = 10_000;
+    uint256 public constant DEFAULT_MINT_TOLL_BPS = 50;
+    uint256 public constant DEFAULT_REDEEM_TOLL_BPS = 50;
+
+    /// @notice Stablecoin whose admin role controls this module.
+    Stablecoin public immutable stablecoin;
+
+    /// @notice Mint toll in basis points.
+    uint256 public mintTollBps;
+    /// @notice Redeem toll in basis points.
+    uint256 public redeemTollBps;
+    /// @notice Governance token bought and burned by the floor pool.
+    address public burnTokenAddress;
+    /// @notice Pool that receives stablecoin tolls.
+    address public floorPoolAddress;
+    /// @notice Minimum stablecoin-side depth required before tolls apply.
+    uint256 public floorPoolMinDepth;
+
+    /// @notice Addresses allowed to route already minted toll balances.
+    mapping(address => bool) public tollOperators;
+
+    event TollConfigUpdated(
+        uint256 mintTollBps,
+        uint256 redeemTollBps,
+        address indexed burnTokenAddress,
+        address indexed floorPoolAddress,
+        uint256 floorPoolMinDepth
+    );
+    event TollOperatorSet(address indexed operator, bool authorized);
+    event TollRouted(
+        address indexed operator,
+        bool indexed mintToll,
+        uint256 stablecoinAmount,
+        address indexed floorPoolAddress,
+        address burnTokenAddress
+    );
+
+    error InvalidBps();
+    error NotStablecoinAdmin(address account);
+    error NotTollOperator(address account);
+    error TollBalanceTooLow(uint256 available, uint256 required);
+    error ZeroAddress();
+
+    modifier onlyStablecoinAdmin() {
+        if (!stablecoin.hasRole(stablecoin.DEFAULT_ADMIN_ROLE(), msg.sender)) {
+            revert NotStablecoinAdmin(msg.sender);
+        }
+        _;
+    }
+
+    modifier onlyTollOperator() {
+        if (!tollOperators[msg.sender]) {
+            revert NotTollOperator(msg.sender);
+        }
+        _;
+    }
+
+    /**
+     * @notice Creates a burn-toll module with the default 0.5% mint and redeem tolls.
+     * @param stablecoin_ Stablecoin whose admin role controls this module.
+     * @param burnTokenAddress_ Governance token bought and burned by the floor pool.
+     * @param floorPoolAddress_ Pool that receives stablecoin tolls.
+     * @param floorPoolMinDepth_ Minimum stablecoin-side depth required before tolls apply.
+     */
+    constructor(
+        address stablecoin_,
+        address burnTokenAddress_,
+        address floorPoolAddress_,
+        uint256 floorPoolMinDepth_
+    ) {
+        if (stablecoin_ == address(0)) revert ZeroAddress();
+        stablecoin = Stablecoin(stablecoin_);
+        _setTollConfig(
+            DEFAULT_MINT_TOLL_BPS,
+            DEFAULT_REDEEM_TOLL_BPS,
+            burnTokenAddress_,
+            floorPoolAddress_,
+            floorPoolMinDepth_
+        );
+    }
+
+    /**
+     * @notice Updates toll rates, burn token, pool address, and minimum pool depth.
+     * @param mintTollBps_ Mint toll in basis points.
+     * @param redeemTollBps_ Redeem toll in basis points.
+     * @param burnTokenAddress_ Governance token bought and burned by the floor pool.
+     * @param floorPoolAddress_ Pool that receives stablecoin tolls.
+     * @param floorPoolMinDepth_ Minimum stablecoin-side depth required before tolls apply.
+     */
+    function setTollConfig(
+        uint256 mintTollBps_,
+        uint256 redeemTollBps_,
+        address burnTokenAddress_,
+        address floorPoolAddress_,
+        uint256 floorPoolMinDepth_
+    ) external onlyStablecoinAdmin {
+        _setTollConfig(
+            mintTollBps_,
+            redeemTollBps_,
+            burnTokenAddress_,
+            floorPoolAddress_,
+            floorPoolMinDepth_
+        );
+    }
+
+    /**
+     * @notice Authorizes or revokes a gateway that may route toll balances.
+     * @param operator Address allowed to call routeMintToll and routeRedeemToll.
+     * @param authorized Whether the operator is authorized.
+     */
+    function setTollOperator(address operator, bool authorized) external onlyStablecoinAdmin {
+        if (operator == address(0)) revert ZeroAddress();
+        tollOperators[operator] = authorized;
+        emit TollOperatorSet(operator, authorized);
+    }
+
+    /**
+     * @notice Previews the mint toll for a gross mint amount.
+     * @param stablecoinAmount Gross stablecoin amount being minted.
+     * @return tollAmount Toll amount, or zero when disabled or skipped.
+     * @return applies True when the toll should be applied.
+     * @return poolDepth Current stablecoin-side pool depth.
+     */
+    function previewMintToll(
+        uint256 stablecoinAmount
+    ) external view returns (uint256 tollAmount, bool applies, uint256 poolDepth) {
+        return _previewToll(stablecoinAmount, mintTollBps);
+    }
+
+    /**
+     * @notice Previews the redeem toll for a gross redeem amount.
+     * @param stablecoinAmount Gross stablecoin amount being redeemed.
+     * @return tollAmount Toll amount, or zero when disabled or skipped.
+     * @return applies True when the toll should be applied.
+     * @return poolDepth Current stablecoin-side pool depth.
+     */
+    function previewRedeemToll(
+        uint256 stablecoinAmount
+    ) external view returns (uint256 tollAmount, bool applies, uint256 poolDepth) {
+        return _previewToll(stablecoinAmount, redeemTollBps);
+    }
+
+    /**
+     * @notice Routes a precomputed mint toll from this contract to the floor pool.
+     * @param tollAmount Stablecoin amount already held by this contract.
+     * @return routedAmount Amount sent to the floor pool.
+     */
+    function routeMintToll(uint256 tollAmount) external onlyTollOperator returns (uint256 routedAmount) {
+        return _routeToll(tollAmount, true);
+    }
+
+    /**
+     * @notice Routes a precomputed redeem toll from this contract to the floor pool.
+     * @param tollAmount Stablecoin amount already held by this contract.
+     * @return routedAmount Amount sent to the floor pool.
+     */
+    function routeRedeemToll(uint256 tollAmount) external onlyTollOperator returns (uint256 routedAmount) {
+        return _routeToll(tollAmount, false);
+    }
+
+    function _setTollConfig(
+        uint256 mintTollBps_,
+        uint256 redeemTollBps_,
+        address burnTokenAddress_,
+        address floorPoolAddress_,
+        uint256 floorPoolMinDepth_
+    ) internal {
+        if (mintTollBps_ > BPS_DENOMINATOR || redeemTollBps_ > BPS_DENOMINATOR) {
+            revert InvalidBps();
+        }
+        if (mintTollBps_ > 0 || redeemTollBps_ > 0) {
+            if (burnTokenAddress_ == address(0) || floorPoolAddress_ == address(0)) {
+                revert ZeroAddress();
+            }
+        }
+
+        mintTollBps = mintTollBps_;
+        redeemTollBps = redeemTollBps_;
+        burnTokenAddress = burnTokenAddress_;
+        floorPoolAddress = floorPoolAddress_;
+        floorPoolMinDepth = floorPoolMinDepth_;
+
+        emit TollConfigUpdated(
+            mintTollBps_,
+            redeemTollBps_,
+            burnTokenAddress_,
+            floorPoolAddress_,
+            floorPoolMinDepth_
+        );
+    }
+
+    function _previewToll(
+        uint256 stablecoinAmount,
+        uint256 tollBps
+    ) internal view returns (uint256 tollAmount, bool applies, uint256 poolDepth) {
+        if (stablecoinAmount == 0 || tollBps == 0) {
+            return (0, false, 0);
+        }
+
+        poolDepth = IBurnTollFloorPool(floorPoolAddress).stablecoinDepth(address(stablecoin));
+        if (poolDepth < floorPoolMinDepth) {
+            return (0, false, poolDepth);
+        }
+
+        tollAmount = (stablecoinAmount * tollBps) / BPS_DENOMINATOR;
+        applies = tollAmount > 0;
+    }
+
+    function _routeToll(uint256 tollAmount, bool mintToll) internal returns (uint256 routedAmount) {
+        if (tollAmount == 0) return 0;
+        if (burnTokenAddress == address(0) || floorPoolAddress == address(0)) {
+            revert ZeroAddress();
+        }
+
+        uint256 balance = IERC20(address(stablecoin)).balanceOf(address(this));
+        if (balance < tollAmount) {
+            revert TollBalanceTooLow(balance, tollAmount);
+        }
+
+        IERC20(address(stablecoin)).safeTransfer(floorPoolAddress, tollAmount);
+        IBurnTollFloorPool(floorPoolAddress).buyAndBurn(burnTokenAddress, tollAmount);
+
+        emit TollRouted(msg.sender, mintToll, tollAmount, floorPoolAddress, burnTokenAddress);
+        return tollAmount;
+    }
+}

--- a/contracts/interfaces/IBurnTollFloorPool.sol
+++ b/contracts/interfaces/IBurnTollFloorPool.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/**
+ * @title IBurnTollFloorPool
+ * @notice Minimal adapter interface for pools that accept stablecoin tolls and
+ *         buy + burn a paired governance token.
+ */
+interface IBurnTollFloorPool {
+    /**
+     * @notice Returns the stablecoin-side pool depth in stablecoin units.
+     * @param stablecoin Address of the stablecoin used to pay the toll.
+     * @return depth Stablecoin liquidity depth, using the stablecoin decimals.
+     */
+    function stablecoinDepth(address stablecoin) external view returns (uint256 depth);
+
+    /**
+     * @notice Uses received stablecoin to buy and burn the configured token.
+     * @param burnToken Address of the governance token to buy and burn.
+     * @param stablecoinAmount Amount of stablecoin routed into the pool.
+     */
+    function buyAndBurn(address burnToken, uint256 stablecoinAmount) external;
+}

--- a/contracts/mocks/BurnTollFloorPoolMock.sol
+++ b/contracts/mocks/BurnTollFloorPoolMock.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../interfaces/IBurnTollFloorPool.sol";
+
+/**
+ * @title BurnTollFloorPoolMock
+ * @notice Test double for a floor pool that receives stablecoin and records buy+burn calls.
+ */
+contract BurnTollFloorPoolMock is IBurnTollFloorPool {
+    /// @notice Stablecoin accepted by the mock pool.
+    IERC20 public immutable stablecoin;
+    /// @notice Reported stablecoin-side pool depth.
+    uint256 public depth;
+    /// @notice Total stablecoin amount accepted through buyAndBurn calls.
+    uint256 public totalStablecoinReceived;
+    /// @notice Total burn-token amount modeled as burned.
+    uint256 public totalBurned;
+    /// @notice Last burn token passed to buyAndBurn.
+    address public lastBurnToken;
+
+    event DepthUpdated(uint256 depth);
+    event BuyAndBurn(address indexed burnToken, uint256 stablecoinAmount);
+
+    /**
+     * @notice Creates a mock floor pool for burn-toll tests.
+     * @param stablecoin_ Stablecoin accepted by the pool.
+     * @param depth_ Initial stablecoin-side depth reported by the pool.
+     */
+    constructor(address stablecoin_, uint256 depth_) {
+        stablecoin = IERC20(stablecoin_);
+        depth = depth_;
+    }
+
+    /**
+     * @notice Updates the reported stablecoin-side pool depth.
+     * @param depth_ New depth in stablecoin units.
+     */
+    function setDepth(uint256 depth_) external {
+        depth = depth_;
+        emit DepthUpdated(depth_);
+    }
+
+    /**
+     * @notice Returns the configured depth for the supported stablecoin.
+     * @param stablecoin_ Stablecoin address being queried.
+     * @return Current depth, or zero for unsupported stablecoins.
+     */
+    function stablecoinDepth(address stablecoin_) external view returns (uint256) {
+        if (stablecoin_ != address(stablecoin)) return 0;
+        return depth;
+    }
+
+    /**
+     * @notice Records a buy+burn call after stablecoin has been transferred in.
+     * @param burnToken Governance token modeled as bought and burned.
+     * @param stablecoinAmount Stablecoin amount routed to the pool.
+     */
+    function buyAndBurn(address burnToken, uint256 stablecoinAmount) external {
+        require(
+            stablecoin.balanceOf(address(this)) >= totalStablecoinReceived + stablecoinAmount,
+            "stablecoin not received"
+        );
+        totalStablecoinReceived += stablecoinAmount;
+        totalBurned += stablecoinAmount;
+        lastBurnToken = burnToken;
+        emit BuyAndBurn(burnToken, stablecoinAmount);
+    }
+}

--- a/docs/burn-toll.md
+++ b/docs/burn-toll.md
@@ -1,0 +1,57 @@
+# BurnToll extension
+
+`BurnToll` is an optional module for deployments that want a mint/redeem toll
+routed into a floor pool. The floor pool receives stablecoin toll revenue, buys
+the paired governance token, and burns it.
+
+## Defaults
+
+- `mintTollBps`: `50` (0.5%)
+- `redeemTollBps`: `50` (0.5%)
+- `burnTokenAddress`: token the floor pool buys and burns
+- `floorPoolAddress`: pool or adapter that receives stablecoin tolls
+- `floorPoolMinDepth`: minimum stablecoin-side pool depth before tolls apply
+
+If the pool depth is below `floorPoolMinDepth`, the module reports a zero toll
+for that mint or redeem so the gateway does not push volume into thin liquidity.
+
+## Wiring
+
+1. Deploy the stablecoin, reserve manager, compliance module, and `Minter`.
+2. Grant the `Minter` the stablecoin `MINTER_ROLE`.
+3. Deploy `BurnToll` with the stablecoin, burn token, floor pool, and minimum depth.
+4. From the stablecoin admin account, call `BurnToll.setTollOperator(minter, true)`.
+5. From the `Minter` owner account, call `Minter.setBurnToll(burnToll)`.
+
+The floor pool must implement `IBurnTollFloorPool`:
+
+```solidity
+function stablecoinDepth(address stablecoin) external view returns (uint256);
+function buyAndBurn(address burnToken, uint256 stablecoinAmount) external;
+```
+
+`Minter` previews the toll before minting or redeeming. When the toll applies,
+it mints the toll amount to `BurnToll`; `BurnToll` transfers that stablecoin to
+the floor pool and calls `buyAndBurn`.
+
+## Governance
+
+The existing stablecoin admin role controls module parameters:
+
+```solidity
+burnToll.setTollConfig(
+    50,
+    50,
+    burnToken,
+    floorPool,
+    100_000_000_000
+);
+```
+
+Set both tolls to zero to disable the module while keeping it wired:
+
+```solidity
+burnToll.setTollConfig(0, 0, address(0), address(0), 0);
+```
+
+`Minter.setBurnToll(address(0))` fully disconnects the hook at the gateway.

--- a/forge-test/BurnToll.t.sol
+++ b/forge-test/BurnToll.t.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/Stablecoin.sol";
+import "../contracts/Minter.sol";
+import "../contracts/ReserveManager.sol";
+import "../contracts/ComplianceModule.sol";
+import "../contracts/extensions/BurnToll.sol";
+import "../contracts/mocks/BurnTollFloorPoolMock.sol";
+
+contract BurnTollTest is Test {
+    uint256 constant USD = 1_000_000;
+    bytes2 constant US = bytes2("US");
+
+    Stablecoin public coin;
+    Minter public minter;
+    ReserveManager public rm;
+    ComplianceModule public cm;
+    BurnToll public burnToll;
+    BurnTollFloorPoolMock public floorPool;
+
+    address public admin = address(1);
+    address public user = address(2);
+    address public feeCollector = address(3);
+    address public burnToken = address(4);
+    address public randomCaller = address(5);
+
+    function setUp() public {
+        vm.startPrank(admin);
+
+        coin = new Stablecoin("Test Stablecoin", "TSTBL", admin);
+        rm = new ReserveManager(10_000);
+        cm = new ComplianceModule();
+
+        rm.addReserveAsset(keccak256("USD_BANK"), "USD Bank", 10_000_000 * USD);
+        cm.setKYC(user, ComplianceModule.KYCStatus.Approved);
+        cm.setGeography(user, US);
+        cm.configureGeography(US, true, 10_000_000 * USD, 10_000_000 * USD);
+
+        minter = new Minter(address(coin), address(rm), address(cm), 0, 0, feeCollector);
+        coin.grantRole(coin.MINTER_ROLE(), address(minter));
+        rm.transferOwnership(address(minter));
+        cm.transferOwnership(address(minter));
+        minter.authorizeMinter(admin);
+
+        floorPool = new BurnTollFloorPoolMock(address(coin), 1_000_000 * USD);
+        burnToll = new BurnToll(address(coin), burnToken, address(floorPool), 100_000 * USD);
+        burnToll.setTollOperator(address(minter), true);
+        minter.setBurnToll(address(burnToll));
+
+        vm.stopPrank();
+    }
+
+    function test_defaultTollMath() public view {
+        (uint256 mintToll, bool mintApplies, ) = burnToll.previewMintToll(1_000 * USD);
+        (uint256 redeemToll, bool redeemApplies, ) = burnToll.previewRedeemToll(1_000 * USD);
+
+        assertEq(mintToll, 5 * USD);
+        assertTrue(mintApplies);
+        assertEq(redeemToll, 5 * USD);
+        assertTrue(redeemApplies);
+    }
+
+    function test_mintRoutesTollToFloorPool() public {
+        vm.prank(admin);
+        minter.mint(user, 1_000 * USD);
+
+        assertEq(coin.balanceOf(user), 995 * USD);
+        assertEq(coin.balanceOf(address(floorPool)), 5 * USD);
+        assertEq(floorPool.totalStablecoinReceived(), 5 * USD);
+        assertEq(floorPool.totalBurned(), 5 * USD);
+        assertEq(floorPool.lastBurnToken(), burnToken);
+    }
+
+    function test_redeemRoutesTollAndQueuesNetRedemption() public {
+        vm.prank(admin);
+        burnToll.setTollConfig(0, 50, burnToken, address(floorPool), 100_000 * USD);
+
+        vm.prank(admin);
+        minter.mint(user, 1_000 * USD);
+
+        vm.prank(user);
+        coin.approve(address(minter), 100 * USD);
+
+        vm.prank(user);
+        minter.redeem(100 * USD);
+
+        assertEq(coin.balanceOf(user), 900 * USD);
+        assertEq(coin.balanceOf(address(floorPool)), USD / 2);
+
+        (, uint256 amount, uint256 fee, , ) = minter.redemptions(0);
+        assertEq(amount, (100 * USD) - (USD / 2));
+        assertEq(fee, 0);
+    }
+
+    function test_skipsWhenLiquidityBelowThreshold() public {
+        floorPool.setDepth(10_000 * USD);
+
+        vm.prank(admin);
+        minter.mint(user, 1_000 * USD);
+
+        assertEq(coin.balanceOf(user), 1_000 * USD);
+        assertEq(coin.balanceOf(address(floorPool)), 0);
+        assertEq(floorPool.totalBurned(), 0);
+    }
+
+    function test_zeroTollConfig() public {
+        vm.prank(admin);
+        burnToll.setTollConfig(0, 0, address(0), address(0), 0);
+
+        vm.prank(admin);
+        minter.mint(user, 1_000 * USD);
+
+        assertEq(coin.balanceOf(user), 1_000 * USD);
+        assertEq(coin.balanceOf(address(floorPool)), 0);
+    }
+
+    function test_accessControl() public {
+        vm.prank(randomCaller);
+        vm.expectRevert(abi.encodeWithSelector(BurnToll.NotStablecoinAdmin.selector, randomCaller));
+        burnToll.setTollConfig(100, 100, burnToken, address(floorPool), 100_000 * USD);
+
+        vm.prank(randomCaller);
+        vm.expectRevert(abi.encodeWithSelector(BurnToll.NotTollOperator.selector, randomCaller));
+        burnToll.routeMintToll(USD);
+    }
+
+    function test_governanceCanReconfigure() public {
+        vm.prank(admin);
+        burnToll.setTollConfig(100, 25, burnToken, address(floorPool), 1_000_000 * USD);
+
+        (uint256 mintToll, , ) = burnToll.previewMintToll(100_000 * USD);
+        (uint256 redeemToll, , ) = burnToll.previewRedeemToll(100_000 * USD);
+
+        assertEq(burnToll.mintTollBps(), 100);
+        assertEq(burnToll.redeemTollBps(), 25);
+        assertEq(mintToll, 1_000 * USD);
+        assertEq(redeemToll, 250 * USD);
+    }
+
+    function test_matrixAmountsAcrossDepths() public {
+        uint256[3] memory amounts = [uint256(1_000 * USD), uint256(100_000 * USD), uint256(1_000_000 * USD)];
+        uint256[3] memory depths = [uint256(10_000 * USD), uint256(100_000 * USD), uint256(1_000_000 * USD)];
+
+        for (uint256 i = 0; i < depths.length; i++) {
+            floorPool.setDepth(depths[i]);
+            for (uint256 j = 0; j < amounts.length; j++) {
+                (uint256 mintToll, , ) = burnToll.previewMintToll(amounts[j]);
+                (uint256 redeemToll, , ) = burnToll.previewRedeemToll(amounts[j]);
+                uint256 expected = depths[i] < 100_000 * USD ? 0 : (amounts[j] * 50) / 10_000;
+
+                assertEq(mintToll, expected);
+                assertEq(redeemToll, expected);
+            }
+        }
+    }
+}

--- a/test/BurnToll.test.js
+++ b/test/BurnToll.test.js
@@ -1,0 +1,201 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+const USD = 1_000_000n;
+
+function usd(amount) {
+  return BigInt(amount) * USD;
+}
+
+async function deployBurnTollStack({ poolDepth = usd(1_000_000), minDepth = usd(100_000) } = {}) {
+  const [admin, user, feeCollector, burnToken, randomCaller] = await ethers.getSigners();
+
+  const Stablecoin = await ethers.getContractFactory("Stablecoin");
+  const stablecoin = await Stablecoin.deploy("Test Stablecoin", "TSTBL", admin.address);
+  await stablecoin.waitForDeployment();
+
+  const ReserveManager = await ethers.getContractFactory("ReserveManager");
+  const reserveManager = await ReserveManager.deploy(10_000n);
+  await reserveManager.waitForDeployment();
+  await reserveManager.addReserveAsset(ethers.id("USD_BANK"), "USD Bank", usd(10_000_000));
+
+  const ComplianceModule = await ethers.getContractFactory("ComplianceModule");
+  const compliance = await ComplianceModule.deploy();
+  await compliance.waitForDeployment();
+  await compliance.setKYC(user.address, 2);
+  await compliance.setGeography(user.address, "0x5553"); // "US"
+  await compliance.configureGeography("0x5553", true, usd(10_000_000), usd(10_000_000));
+
+  const Minter = await ethers.getContractFactory("Minter");
+  const minter = await Minter.deploy(
+    await stablecoin.getAddress(),
+    await reserveManager.getAddress(),
+    await compliance.getAddress(),
+    0n,
+    0n,
+    feeCollector.address,
+  );
+  await minter.waitForDeployment();
+
+  await stablecoin.grantRole(await stablecoin.MINTER_ROLE(), await minter.getAddress());
+  await reserveManager.transferOwnership(await minter.getAddress());
+  await compliance.transferOwnership(await minter.getAddress());
+  await minter.authorizeMinter(admin.address);
+
+  const BurnTollFloorPoolMock = await ethers.getContractFactory("BurnTollFloorPoolMock");
+  const floorPool = await BurnTollFloorPoolMock.deploy(await stablecoin.getAddress(), poolDepth);
+  await floorPool.waitForDeployment();
+
+  const BurnToll = await ethers.getContractFactory("BurnToll");
+  const burnToll = await BurnToll.deploy(
+    await stablecoin.getAddress(),
+    burnToken.address,
+    await floorPool.getAddress(),
+    minDepth,
+  );
+  await burnToll.waitForDeployment();
+
+  await burnToll.setTollOperator(await minter.getAddress(), true);
+  await minter.setBurnToll(await burnToll.getAddress());
+
+  return {
+    admin,
+    user,
+    feeCollector,
+    burnToken,
+    randomCaller,
+    stablecoin,
+    reserveManager,
+    compliance,
+    minter,
+    floorPool,
+    burnToll,
+  };
+}
+
+describe("BurnToll", function () {
+  it("previews the default 0.5% mint and redeem tolls", async function () {
+    const { burnToll } = await deployBurnTollStack();
+
+    const [mintToll, mintApplies] = await burnToll.previewMintToll(usd(1_000));
+    const [redeemToll, redeemApplies] = await burnToll.previewRedeemToll(usd(1_000));
+
+    expect(mintToll).to.equal(usd(5));
+    expect(mintApplies).to.equal(true);
+    expect(redeemToll).to.equal(usd(5));
+    expect(redeemApplies).to.equal(true);
+  });
+
+  it("routes the mint toll to the floor pool and buys/burns the paired token", async function () {
+    const { stablecoin, minter, floorPool, burnToken, user } = await deployBurnTollStack();
+
+    await minter.mint(user.address, usd(1_000));
+
+    expect(await stablecoin.balanceOf(user.address)).to.equal(usd(995));
+    expect(await stablecoin.balanceOf(await floorPool.getAddress())).to.equal(usd(5));
+    expect(await floorPool.totalStablecoinReceived()).to.equal(usd(5));
+    expect(await floorPool.totalBurned()).to.equal(usd(5));
+    expect(await floorPool.lastBurnToken()).to.equal(burnToken.address);
+    expect(await stablecoin.totalSupply()).to.equal(usd(1_000));
+  });
+
+  it("routes the redeem toll and queues the net redemption", async function () {
+    const { stablecoin, minter, burnToll, floorPool, burnToken, user } = await deployBurnTollStack();
+
+    await burnToll.setTollConfig(
+      0n,
+      50n,
+      burnToken.address,
+      await floorPool.getAddress(),
+      usd(100_000),
+    );
+    await minter.mint(user.address, usd(1_000));
+    await stablecoin.connect(user).approve(await minter.getAddress(), usd(100));
+
+    await expect(minter.connect(user).redeem(usd(100)))
+      .to.emit(minter, "RedemptionQueued")
+      .withArgs(0n, user.address, 99_500_000n);
+
+    expect(await stablecoin.balanceOf(user.address)).to.equal(usd(900));
+    expect(await stablecoin.balanceOf(await floorPool.getAddress())).to.equal(500_000n);
+    expect(await stablecoin.totalSupply()).to.equal(usd(900) + 500_000n);
+
+    const redemption = await minter.redemptions(0);
+    expect(redemption.redeemer).to.equal(user.address);
+    expect(redemption.amount).to.equal(99_500_000n);
+    expect(redemption.fee).to.equal(0n);
+  });
+
+  it("skips tolls when floor pool depth is below the configured threshold", async function () {
+    const { stablecoin, minter, floorPool, user } = await deployBurnTollStack({
+      poolDepth: usd(10_000),
+      minDepth: usd(100_000),
+    });
+
+    await minter.mint(user.address, usd(1_000));
+
+    expect(await stablecoin.balanceOf(user.address)).to.equal(usd(1_000));
+    expect(await stablecoin.balanceOf(await floorPool.getAddress())).to.equal(0n);
+    expect(await floorPool.totalBurned()).to.equal(0n);
+  });
+
+  it("allows stablecoin governance to disable tolls entirely", async function () {
+    const { stablecoin, minter, burnToll, floorPool, user } = await deployBurnTollStack();
+
+    await burnToll.setTollConfig(0n, 0n, ethers.ZeroAddress, ethers.ZeroAddress, 0n);
+    await minter.mint(user.address, usd(1_000));
+    await stablecoin.connect(user).approve(await minter.getAddress(), usd(100));
+    await minter.connect(user).redeem(usd(100));
+
+    expect(await stablecoin.balanceOf(user.address)).to.equal(usd(900));
+    expect(await stablecoin.balanceOf(await floorPool.getAddress())).to.equal(0n);
+    expect(await floorPool.totalBurned()).to.equal(0n);
+  });
+
+  it("gates configuration and routing with the expected roles", async function () {
+    const { burnToll, floorPool, burnToken, randomCaller } = await deployBurnTollStack();
+
+    await expect(
+      burnToll
+        .connect(randomCaller)
+        .setTollConfig(100n, 100n, burnToken.address, await floorPool.getAddress(), usd(100_000)),
+    ).to.be.revertedWithCustomError(burnToll, "NotStablecoinAdmin");
+
+    await expect(burnToll.connect(randomCaller).routeMintToll(usd(1))).to.be.revertedWithCustomError(
+      burnToll,
+      "NotTollOperator",
+    );
+  });
+
+  it("lets stablecoin governance reconfigure toll rates and pool depth", async function () {
+    const { burnToll, floorPool, burnToken } = await deployBurnTollStack();
+
+    await burnToll.setTollConfig(100n, 25n, burnToken.address, await floorPool.getAddress(), usd(1_000_000));
+
+    const [mintToll] = await burnToll.previewMintToll(usd(100_000));
+    const [redeemToll] = await burnToll.previewRedeemToll(usd(100_000));
+
+    expect(await burnToll.mintTollBps()).to.equal(100n);
+    expect(await burnToll.redeemTollBps()).to.equal(25n);
+    expect(mintToll).to.equal(usd(1_000));
+    expect(redeemToll).to.equal(usd(250));
+  });
+
+  it("covers $1K, $100K, and $1M scenarios across three pool depths", async function () {
+    const { burnToll, floorPool } = await deployBurnTollStack({ minDepth: usd(100_000) });
+    const amounts = [usd(1_000), usd(100_000), usd(1_000_000)];
+    const depths = [usd(10_000), usd(100_000), usd(1_000_000)];
+
+    for (const depth of depths) {
+      await floorPool.setDepth(depth);
+      for (const amount of amounts) {
+        const [mintToll] = await burnToll.previewMintToll(amount);
+        const [redeemToll] = await burnToll.previewRedeemToll(amount);
+        const expected = depth < usd(100_000) ? 0n : (amount * 50n) / 10_000n;
+
+        expect(mintToll).to.equal(expected);
+        expect(redeemToll).to.equal(expected);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Adds an optional BurnToll extension that can route configurable mint and redeem tolls into a floor pool that buys and burns a paired governance token.

The module defaults to 0.5% mint and redeem tolls, skips tolls when pool depth is below the configured minimum, and lets the existing stablecoin admin role update parameters.

## What changed
- Added BurnToll extension and floor-pool interface
- Wired Minter to apply tolls when a BurnToll module is enabled
- Added mock floor pool for tests
- Added Hardhat and Foundry test coverage
- Added deployment/wiring documentation
- Fixed redemption event reporting so it emits the net redemption amount after tolls

## Checks
- npm run compile
- npm test
- git diff --check
- secret-pattern scan

Note: Foundry tests were added but not run locally because forge is not installed in this environment.