### PR TITLE
feat: add multi-geography deployment plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Built on learnings from real stablecoin deployments. Production-grade Solidity c
 - **Minting gateway** — compliance-checked minting, redemption queue, fee management
 - **Depeg defence** — `DepegGuard` state machine monitors the collateral price feed and pauses mints / stablecoin on threshold breaches; see [`docs/depeg-guard.md`](docs/depeg-guard.md)
 - **Multi-geography** — configurable per jurisdiction (see `config/geographies/`)
+- **Deployment scripts** — India, Singapore, and UAE deployment plans with jurisdiction-specific compliance limits; see [`docs/multi-geography-deployments.md`](docs/multi-geography-deployments.md)
 - **Role-based access** — MINTER, PAUSER, BLACKLISTER roles via OpenZeppelin AccessControl
 
 ## Getting Started

--- a/config/geographies/singapore.json
+++ b/config/geographies/singapore.json
@@ -1,0 +1,34 @@
+{
+  "geography": "SG",
+  "name": "Singapore",
+  "stablecoin": {
+    "name": "Singapore Dollar Stablecoin",
+    "symbol": "SGDR",
+    "decimals": 6
+  },
+  "compliance": {
+    "kyc_required": true,
+    "max_transaction_amount": 25000000000,
+    "daily_limit": 100000000000,
+    "notes": "MAS Payment Services Act deployment profile. Amounts are in 6-decimal units.",
+    "regulatory": {
+      "major_payment_institution_license": true,
+      "travel_rule_controls": true
+    }
+  },
+  "reserves": {
+    "minimum_ratio_bps": 10000,
+    "accepted_assets": [
+      "SGD bank deposits",
+      "Singapore Government Securities",
+      "MAS bills"
+    ],
+    "bootstrap_asset_id": "SG_RESERVE",
+    "bootstrap_asset_name": "Singapore fiat reserve",
+    "bootstrap_amount": "0"
+  },
+  "fees": {
+    "mint_bps": 12,
+    "redeem_bps": 12
+  }
+}

--- a/config/geographies/uae.json
+++ b/config/geographies/uae.json
@@ -1,0 +1,36 @@
+{
+  "geography": "AE",
+  "aliases": ["UAE"],
+  "name": "United Arab Emirates",
+  "stablecoin": {
+    "name": "UAE Dirham Stablecoin",
+    "symbol": "AEDR",
+    "decimals": 6
+  },
+  "compliance": {
+    "kyc_required": true,
+    "max_transaction_amount": 50000000000,
+    "daily_limit": 200000000000,
+    "notes": "UAE deployment profile using ISO alpha-2 AE for on-chain bytes2 geography checks. Amounts are in 6-decimal units.",
+    "regulatory": {
+      "vara_alignment": true,
+      "aml_cft_controls": true,
+      "travel_rule_controls": true
+    }
+  },
+  "reserves": {
+    "minimum_ratio_bps": 10000,
+    "accepted_assets": [
+      "AED bank deposits",
+      "UAE government securities",
+      "USD short-term treasury bills"
+    ],
+    "bootstrap_asset_id": "AE_RESERVE",
+    "bootstrap_asset_name": "UAE fiat reserve",
+    "bootstrap_amount": "0"
+  },
+  "fees": {
+    "mint_bps": 15,
+    "redeem_bps": 15
+  }
+}

--- a/docs/multi-geography-deployments.md
+++ b/docs/multi-geography-deployments.md
@@ -1,0 +1,32 @@
+# Multi-Geography Deployments
+
+`scripts/deploy-multi-geo.js` deploys the current toolkit stack for India, Singapore, and the United Arab Emirates.
+
+## Dry Run
+
+```bash
+node scripts/deploy-multi-geo.js --geo IN --geo SG --geo UAE --dry-run
+```
+
+Use this before a live deployment to verify the stablecoin names, symbols, fee rates, reserve ratios, and geography limits read from `config/geographies/`.
+
+## Local Deployment
+
+```bash
+npx hardhat node
+HARDHAT_NETWORK=localhost node scripts/deploy-multi-geo.js --geo IN
+HARDHAT_NETWORK=localhost node scripts/deploy-multi-geo.js --geo SG --geo UAE
+```
+
+Each deployment writes `deployments/<network>/<geography>-deployment.json` with the deployed `Stablecoin`, `ReserveManager`, `ComplianceModule`, and `Minter` addresses.
+
+## Adding A Geography
+
+1. Copy `config/geographies/template.json`.
+2. Set `geography` to an ISO 3166-1 alpha-2 code because `ComplianceModule` stores the value as `bytes2`.
+3. Set `stablecoin.name`, `stablecoin.symbol`, and the fee profile.
+4. Set `compliance.max_transaction_amount` and `compliance.daily_limit` in 6-decimal stablecoin units.
+5. Add reserve metadata and optional `bootstrap_amount`.
+6. Run the dry-run command with the new `--geo` value.
+
+The deployment script configures `ComplianceModule.configureGeography(...)`, grants the stablecoin minter role to `Minter`, authorizes the deployer as an initial minter, and transfers reserve/compliance ownership to `Minter` so mint and redeem checks stay enforced through the gateway.

--- a/scripts/deploy-multi-geo.js
+++ b/scripts/deploy-multi-geo.js
@@ -1,216 +1,269 @@
 #!/usr/bin/env node
 /**
  * Multi-geography Stablecoin Deployment Script
- * 
+ *
  * Deploys stablecoin contracts configured for different jurisdictions.
- * 
+ *
  * Usage:
- *   node scripts/deploy-multi-geo.js --geo US
- *   node scripts/deploy-multi-geo.js --geo EU
- *   node scripts/deploy-multi-geo.js --geo LATAM
- *   node scripts/deploy-multi-geo.js --all    # Deploy all geographies
- * 
- * Supported geographies: US, EU, LATAM
+ *   HARDHAT_NETWORK=localhost node scripts/deploy-multi-geo.js --geo IN
+ *   HARDHAT_NETWORK=localhost node scripts/deploy-multi-geo.js --geo SG --geo UAE
+ *   node scripts/deploy-multi-geo.js --geo IN --geo SG --geo UAE --dry-run
  */
 
-const fs = require('fs');
-const path = require('path');
-const hre = require('hardhat');
+const fs = require("fs");
+const path = require("path");
 
-const GEO_CONFIG_DIR = path.join(__dirname, '..', 'config', 'geographies');
+const GEO_CONFIG_DIR = path.join(__dirname, "..", "config", "geographies");
+const DEPLOYMENT_GEOS = ["IN", "SG", "UAE"];
+const GEO_ALIASES = {
+  AE: "uae",
+  EU: "eu",
+  IN: "india",
+  INDIA: "india",
+  LATAM: "latam",
+  SG: "singapore",
+  SINGAPORE: "singapore",
+  UAE: "uae",
+  US: "us",
+};
 
-// Load geography configuration
 function loadGeoConfig(geo) {
-  const configPath = path.join(GEO_CONFIG_DIR, `${geo.toLowerCase()}.json`);
+  const normalized = geo.toUpperCase();
+  const slug = GEO_ALIASES[normalized] || geo.toLowerCase();
+  const configPath = path.join(GEO_CONFIG_DIR, `${slug}.json`);
   if (!fs.existsSync(configPath)) {
     throw new Error(`Geography config not found: ${configPath}`);
   }
-  return JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  return JSON.parse(fs.readFileSync(configPath, "utf8"));
 }
 
-// Deploy contracts for a single geography
-async function deployForGeo(geo, options = {}) {
+function geographyBytes2(geography) {
+  if (!/^[A-Z]{2}$/.test(geography)) {
+    throw new Error(`ComplianceModule geography must be ISO 3166-1 alpha-2 bytes2, got ${geography}`);
+  }
+  return geography;
+}
+
+function toBytes2(hre, geography) {
+  geographyBytes2(geography);
+  return hre.ethers.hexlify(hre.ethers.toUtf8Bytes(geography));
+}
+
+function buildDeploymentPlan(geo) {
   const config = loadGeoConfig(geo);
+  geographyBytes2(config.geography);
+  return {
+    geography: config.geography,
+    name: config.name,
+    stablecoin: config.stablecoin,
+    compliance: {
+      kycRequired: config.compliance.kyc_required,
+      maxTransactionAmount: config.compliance.max_transaction_amount,
+      dailyLimit: config.compliance.daily_limit,
+    },
+    reserves: {
+      minimumRatioBps: config.reserves.minimum_ratio_bps,
+      bootstrapAssetId: config.reserves.bootstrap_asset_id || `${config.geography}_RESERVE`,
+      bootstrapAssetName: config.reserves.bootstrap_asset_name || `${config.name} reserve`,
+      bootstrapAmount: config.reserves.bootstrap_amount || "0",
+    },
+    fees: {
+      mintBps: config.fees.mint_bps,
+      redeemBps: config.fees.redeem_bps,
+    },
+  };
+}
+
+function parseArgs(argv) {
+  const options = {
+    geos: [],
+    dryRun: false,
+    list: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--geo" && argv[i + 1]) {
+      options.geos.push(argv[i + 1].toUpperCase());
+      i++;
+    } else if (argv[i] === "--all") {
+      options.geos = [...DEPLOYMENT_GEOS];
+    } else if (argv[i] === "--dry-run") {
+      options.dryRun = true;
+    } else if (argv[i] === "--list") {
+      options.list = true;
+    }
+  }
+  return options;
+}
+
+function printUsage() {
+  console.log(`
+Multi-geography Stablecoin Deployment
+
+Usage:
+  HARDHAT_NETWORK=localhost node scripts/deploy-multi-geo.js --geo IN
+  HARDHAT_NETWORK=localhost node scripts/deploy-multi-geo.js --geo SG --geo UAE
+  HARDHAT_NETWORK=localhost node scripts/deploy-multi-geo.js --all
+  node scripts/deploy-multi-geo.js --geo IN --geo SG --geo UAE --dry-run
+  node scripts/deploy-multi-geo.js --list
+
+Primary geographies for issue #6:
+  IN  - India
+  SG  - Singapore
+  UAE - United Arab Emirates (configures ComplianceModule geography as AE)
+`);
+}
+
+async function deployForGeo(geo, options = {}) {
+  const hre = require("hardhat");
+  const plan = buildDeploymentPlan(geo);
   const network = hre.network.name;
   const deployer = (await hre.ethers.getSigners())[0];
+  const deployerAddress = await deployer.getAddress();
 
   console.log(`\n${'='.repeat(60)}`);
-  console.log(`Deploying ${config.name} Stablecoin (${config.geography})`);
+  console.log(`Deploying ${plan.name} Stablecoin (${plan.geography})`);
   console.log(`Network: ${network}`);
-  console.log(`Deployer: ${deployer.address}`);
-  console.log('='.repeat(60));
+  console.log(`Deployer: ${deployerAddress}`);
+  console.log("=".repeat(60));
 
-  // Deploy Mock ERC20 tokens for reserves (for testing)
-  // In production, these would be real reserve assets
-  const MockToken = await hre.ethers.getContractFactory('MockERC20');
-  
-  const reserveTokens = {};
-  if (config.reserves.accepted_assets.includes('USD bank deposits') || 
-      config.reserves.accepted_assets.includes('US Treasury bills')) {
-    const USDT = await MockToken.deploy('USD Tether', 'USDT', 6);
-    await USDT.deployed();
-    reserveTokens.usd = USDT.address;
-    console.log(`Mock USDT deployed: ${USDT.address}`);
+  const ReserveManager = await hre.ethers.getContractFactory("ReserveManager");
+  const reserveManager = await ReserveManager.deploy(plan.reserves.minimumRatioBps);
+  await reserveManager.waitForDeployment();
+  const reserveManagerAddress = await reserveManager.getAddress();
+  console.log(`ReserveManager deployed: ${reserveManagerAddress}`);
+
+  const ComplianceModule = await hre.ethers.getContractFactory("ComplianceModule");
+  const complianceModule = await ComplianceModule.deploy();
+  await complianceModule.waitForDeployment();
+  const complianceModuleAddress = await complianceModule.getAddress();
+  console.log(`ComplianceModule deployed: ${complianceModuleAddress}`);
+
+  await complianceModule.configureGeography(
+    toBytes2(hre, plan.geography),
+    true,
+    plan.compliance.maxTransactionAmount,
+    plan.compliance.dailyLimit
+  );
+  console.log(`Compliance geography configured: ${plan.geography}`);
+
+  if (BigInt(plan.reserves.bootstrapAmount) > 0n) {
+    await reserveManager.addReserveAsset(
+      hre.ethers.id(plan.reserves.bootstrapAssetId),
+      plan.reserves.bootstrapAssetName,
+      plan.reserves.bootstrapAmount
+    );
+    console.log(`Reserve bootstrap configured: ${plan.reserves.bootstrapAssetName}`);
   }
 
-  if (config.reserves.accepted_assets.includes('EUR bank deposits')) {
-    const EUROC = await MockToken.deploy('Euro Coin', 'EUROC', 6);
-    await EUROC.deployed();
-    reserveTokens.eur = EUROC.address;
-    console.log(`Mock EUROC deployed: ${EUROC.address}`);
-  }
+  const Stablecoin = await hre.ethers.getContractFactory("Stablecoin");
+  const stablecoin = await Stablecoin.deploy(plan.stablecoin.name, plan.stablecoin.symbol, deployerAddress);
+  await stablecoin.waitForDeployment();
+  const stablecoinAddress = await stablecoin.getAddress();
+  console.log(`Stablecoin (${plan.stablecoin.symbol}) deployed: ${stablecoinAddress}`);
 
-  // Deploy Reserve Manager
-  const ReserveManager = await hre.ethers.getContractFactory('ReserveManager');
-  const reserveManager = await ReserveManager.deploy(
-    config.reserves.minimum_ratio_bps,  // minimumReserveRatioBps
-    deployer.address  // governance
+  const Minter = await hre.ethers.getContractFactory("Minter");
+  const minter = await Minter.deploy(
+    stablecoinAddress,
+    reserveManagerAddress,
+    complianceModuleAddress,
+    plan.fees.mintBps,
+    plan.fees.redeemBps,
+    deployerAddress
   );
-  await reserveManager.deployed();
-  console.log(`ReserveManager deployed: ${reserveManager.address}`);
+  await minter.waitForDeployment();
+  const minterAddress = await minter.getAddress();
+  console.log(`Minter deployed: ${minterAddress}`);
 
-  // Deploy Compliance Module
-  const ComplianceModule = await hre.ethers.getContractFactory('ComplianceModule');
-  const complianceModule = await ComplianceModule.deploy(
-    config.compliance.kyc_required,
-    config.compliance.max_transaction_amount,
-    config.compliance.daily_limit,
-    deployer.address
-  );
-  await complianceModule.deployed();
-  console.log(`ComplianceModule deployed: ${complianceModule.address}`);
-
-  // Deploy Stablecoin
-  const Stablecoin = await hre.ethers.getContractFactory('Stablecoin');
-  const stablecoin = await Stablecoin.deploy(
-    config.stablecoin.name,
-    config.stablecoin.symbol,
-    config.stablecoin.decimals,
-    deployer.address,  // governance
-    complianceModule.address,
-    reserveManager.address
-  );
-  await stablecoin.deployed();
-  console.log(`Stablecoin (${config.stablecoin.symbol}) deployed: ${stablecoin.address}`);
-
-  // Deploy Minting Gateway
-  const MintingGateway = await hre.ethers.getContractFactory('MintingGateway');
-  const mintingGateway = await MintingGateway.deploy(
-    stablecoin.address,
-    complianceModule.address,
-    reserveManager.address,
-    config.fees.mint_bps,
-    config.fees.redeem_bps,
-    deployer.address
-  );
-  await mintingGateway.deployed();
-  console.log(`MintingGateway deployed: ${mintingGateway.address}`);
-
-  // Grant roles
   const MINTER_ROLE = await stablecoin.MINTER_ROLE();
-  const PAUSER_ROLE = await stablecoin.PAUSER_ROLE();
-  
-  await stablecoin.grantRole(MINTER_ROLE, mintingGateway.address);
-  await stablecoin.grantRole(PAUSER_ROLE, deployer.address);
-  console.log('Roles configured');
+  await stablecoin.grantRole(MINTER_ROLE, minterAddress);
+  await minter.authorizeMinter(deployerAddress);
+  await reserveManager.transferOwnership(minterAddress);
+  await complianceModule.transferOwnership(minterAddress);
+  console.log("Roles and ownership configured");
 
-  // Output deployment info
   const deploymentInfo = {
-    geography: config.geography,
-    network: network,
-    deployer: deployer.address,
+    geography: plan.geography,
+    network,
+    deployer: deployerAddress,
     timestamp: new Date().toISOString(),
     contracts: {
-      stablecoin: stablecoin.address,
-      complianceModule: complianceModule.address,
-      reserveManager: reserveManager.address,
-      mintingGateway: mintingGateway.address,
-      reserveTokens: reserveTokens
+      stablecoin: stablecoinAddress,
+      complianceModule: complianceModuleAddress,
+      reserveManager: reserveManagerAddress,
+      minter: minterAddress,
     },
-    config: {
-      stablecoin: config.stablecoin,
-      compliance: config.compliance,
-      reserves: config.reserves,
-      fees: config.fees
-    }
+    config: plan,
   };
 
-  // Save deployment info
-  const deployDir = path.join(__dirname, '..', 'deployments', network);
+  const deployDir = path.join(__dirname, "..", "deployments", network);
   fs.mkdirSync(deployDir, { recursive: true });
-  const deployFile = path.join(deployDir, `${config.geography.toLowerCase()}-deployment.json`);
+  const deployFile = path.join(deployDir, `${plan.geography.toLowerCase()}-deployment.json`);
   fs.writeFileSync(deployFile, JSON.stringify(deploymentInfo, null, 2));
   console.log(`\nDeployment info saved to: ${deployFile}`);
 
   return deploymentInfo;
 }
 
-// Main execution
 async function main() {
-  const args = process.argv.slice(2);
-  let geos = [];
-  let options = {};
+  const options = parseArgs(process.argv.slice(2));
 
-  // Parse arguments
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--geo' && args[i + 1]) {
-      geos.push(args[i + 1].toUpperCase());
-      i++;
-    } else if (args[i] === '--all') {
-      geos = ['US', 'EU', 'LATAM'];
-    } else if (args[i] === '--verify') {
-      options.verify = true;
-    }
-  }
-
-  if (geos.length === 0) {
-    console.log(`
-Multi-geography Stablecoin Deployment
-
-Usage:
-  node scripts/deploy-multi-geo.js --geo US
-  node scripts/deploy-multi-geo.js --geo EU
-  node scripts/deploy-multi-geo.js --geo LATAM
-  node scripts/deploy-multi-geo.js --all
-  node scripts/deploy-multi-geo.js --geo US --verify
-
-Supported geographies:
-  US  - United States (FinCEN, state MTL compliant)
-  EU  - European Union (MiCA compliant)
-  LATAM - Latin America (low KYC, high accessibility)
-`);
+  if (options.list) {
+    console.log(JSON.stringify(DEPLOYMENT_GEOS.map(buildDeploymentPlan), null, 2));
     return;
   }
 
-  console.log(`Starting deployment for: ${geos.join(', ')}`);
+  if (options.geos.length === 0) {
+    printUsage();
+    return;
+  }
+
+  if (options.dryRun) {
+    console.log(JSON.stringify(options.geos.map(buildDeploymentPlan), null, 2));
+    return;
+  }
+
+  console.log(`Starting deployment for: ${options.geos.join(", ")}`);
 
   const deployments = [];
-  for (const geo of geos) {
+  const failures = [];
+  for (const geo of options.geos) {
     try {
       const deployment = await deployForGeo(geo, options);
       deployments.push(deployment);
     } catch (error) {
       console.error(`Failed to deploy for ${geo}:`, error.message);
+      failures.push(geo);
     }
   }
 
-  // Summary
   console.log(`\n${'='.repeat(60)}`);
-  console.log('DEPLOYMENT SUMMARY');
-  console.log('='.repeat(60));
+  console.log("DEPLOYMENT SUMMARY");
+  console.log("=".repeat(60));
   for (const dep of deployments) {
     console.log(`\n${dep.geography} (${dep.config.stablecoin.symbol}):`);
     console.log(`  Stablecoin: ${dep.contracts.stablecoin}`);
     console.log(`  Compliance:  ${dep.contracts.complianceModule}`);
     console.log(`  Reserve:     ${dep.contracts.reserveManager}`);
-    console.log(`  Gateway:     ${dep.contracts.mintingGateway}`);
+    console.log(`  Minter:      ${dep.contracts.minter}`);
   }
-  console.log(`\nTotal deployed: ${deployments.length}/${geos.length}`);
+  console.log(`\nTotal deployed: ${deployments.length}/${options.geos.length}`);
+  if (failures.length > 0) {
+    throw new Error(`Deployment failed for: ${failures.join(", ")}`);
+  }
 }
 
-main()
-  .then(() => process.exit(0))
-  .catch((error) => {
-    console.error(error);
-    process.exit(1);
-  });
+if (require.main === module) {
+  main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}
+
+module.exports = {
+  buildDeploymentPlan,
+  loadGeoConfig,
+  parseArgs,
+  toBytes2,
+};


### PR DESCRIPTION
Implements #6.

## Summary
- Reworks `scripts/deploy-multi-geo.js` against the current `Stablecoin`, `ReserveManager`, `ComplianceModule`, and `Minter` constructors.
- Adds India/Singapore/UAE deployment planning, with UAE mapped to ISO alpha-2 `AE` for `bytes2` compliance checks.
- Adds Singapore and UAE geography configs with KYC, transaction-limit, daily-limit, reserve, and fee profiles.
- Documents dry-run, local deployment, and new geography onboarding in `docs/multi-geography-deployments.md`.

## Validation
- `node scripts/deploy-multi-geo.js --geo IN --geo SG --geo UAE --dry-run`
- `node scripts/deploy-multi-geo.js --geo IN`
- `node scripts/deploy-multi-geo.js --geo SG --geo UAE`
- `npx hardhat test`
- `git diff --check`