### PR TITLE
chore: make local forge test workflow discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ npx hardhat compile
 # Run tests
 npx hardhat test
 
+# Run Foundry tests
+forge test
+# or: npm run test:forge
+
 # Deploy locally
 npx hardhat node &
 npx hardhat run scripts/deploy.js --network localhost
@@ -142,6 +146,12 @@ config/geographies/
 | `Minter.sol` | Gateway — compliance + reserve checks before mint/redeem |
 | `DepegGuard.sol` | Depeg-defence watchdog — Normal/Caution/Hard state machine, pauses mints + stablecoin on threshold breaches. Spec: [`docs/depeg-guard.md`](docs/depeg-guard.md) |
 | `ChainlinkPoRAdapter.sol` | Adapter for Chainlink Proof of Reserves feeds |
+
+## Foundry notes
+
+- Forge tests live under `forge-test/` and are wired through `foundry.toml`, so plain `forge test` works after `npm install`.
+- `lib/forge-std` is already vendored for the test harness; no extra `forge install` step is needed for a normal local checkout.
+- If `forge` is installed outside your shell `PATH`, invoke it with your local Foundry bin path or add that directory to `PATH` first.
 
 ## Contributing
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,8 @@
 [profile.default]
 src = "contracts"
+test = "forge-test"
 out = "forge-out"
-libs = ["node_modules"]
+libs = ["node_modules", "lib"]
 solc = "0.8.24"
 optimizer = true
 optimizer-runs = 200

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "compile": "hardhat compile",
     "test": "hardhat test",
+    "test:forge": "forge test -vvv",
     "deploy:local": "hardhat run scripts/deploy.js --network localhost"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- point Foundry at `forge-test/` in `foundry.toml` so plain `forge test` discovers the suite
- add `npm run test:forge` as a documented local entrypoint
- document the local Foundry workflow in the README

## Testing
- `PATH=/home/alex/.foundry/bin:$PATH npm run test:forge`

This is a small contributor-experience cleanup rather than a functional contract change.