### PR TITLE
Fix forge-std remapping for invariant CI

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,7 @@ src = "contracts"
 test = "forge-test"
 out = "forge-out"
 libs = ["node_modules", "lib"]
-remappings = ["forge-std/=forge-std/"]
+remappings = ["forge-std/=lib/forge-std/src/"]
 solc = "0.8.24"
 optimizer = true
 optimizer-runs = 200


### PR DESCRIPTION
## Summary

- fixes the Forge remapping introduced with the invariant tests
- points `forge-std/` imports at the installed Foundry library under `lib/forge-std/src/`
- keeps the change scoped to `foundry.toml`

## Why

`main` and #45 currently fail `forge test` because `forge-std/StdInvariant.sol` resolves through the local `forge-std/` shim directory, which only contains `Test.sol`. The workflow already installs `foundry-rs/forge-std`, so the remapping should target that installed package instead.

## Validation

- GitHub Actions should rerun the existing `forge` workflow on this one-line config change.
